### PR TITLE
Add additional maintainer and codeowner (see #85)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @eric-murray @bigludo7 @sachinvodafone
+* @eric-murray @bigludo7 @sachinvodafone @akoshunyadi

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,6 +1,7 @@
 | Org                    | Name                                                |
 | -----------------------| ----------------------------------------------------|
 | Deutsche Telekom AG | Noel Wirzius |
+| Deutsche Telekom AG | Akos Hunyadi |
 | Orange | Sylvain Morel |
 | Orange| Ludovic Robert|
 | Telefonica | Jesus Pena |


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Adding Akos Hunyadi @akoshunyadi to MAINTAINER.md and CODEOWNER file.

#### Which issue(s) this PR fixes:

Fixes #85 

#### Special notes for reviewers:

See issue #85 

#### Changelog input

na

