### PR TITLE
Make subscriptionDetail/device and CloudEvent/data mandatory

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -652,6 +652,7 @@ components:
       type: object
       required:
         - type
+        - device
       properties:
         device:
           $ref: "#/components/schemas/Device"
@@ -752,6 +753,7 @@ components:
         - specversion
         - type
         - time
+        - data
       properties:
         id:
           type: string


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Make subscriptionDetail/device and CloudEvent/data mandatory


#### Which issue(s) this PR fixes:

Fixes #84 

#### Special notes for reviewers:


#### Changelog input


#### Additional documentation 
