### PR TITLE
feat: use simple String for "type" in CloudEvent

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -652,34 +652,6 @@ components:
         type:
           $ref: "#/components/schemas/SubscriptionCreationEventType"
 
-    SubscriptionEventType:
-      type: string
-      description: |
-        roaming-status - Event triggered when the device switch from roaming ON to roaming OFF and conversely
-
-        roaming-on - Event triggered when the device switch from roaming OFF to roaming ON
-
-        roaming-off - Event triggered when the device switch from roaming ON to roaming OFF
-
-        roaming-change-country - Event triggered when the device in roaming change country code
-
-        connectivity-data - Event triggered when the device is connected to the network for Data usage.
-
-        connectivity-sms - Event triggered when the device is connected to the network for SMS usage
-
-        connectivity-disconnected - Event triggered when the device is not connected.
-
-        subscription-ends - Event triggered when the subscription is terminated
-      enum:
-        - org.camaraproject.device-status.v0.roaming-status
-        - org.camaraproject.device-status.v0.roaming-on
-        - org.camaraproject.device-status.v0.roaming-off
-        - org.camaraproject.device-status.v0.roaming-change-country
-        - org.camaraproject.device-status.v0.connectivity-data
-        - org.camaraproject.device-status.v0.connectivity-sms
-        - org.camaraproject.device-status.v0.connectivity-disconnected
-        - org.camaraproject.device-status.v0.subscription-ends
-
     SubscriptionCreationEventType:
       type: string
       description: |
@@ -755,7 +727,8 @@ components:
         source:
           $ref: "#/components/schemas/Source"
         type:
-          $ref: "#/components/schemas/SubscriptionEventType"
+          type: string
+          description: Specifies the type of event for which the event will be sent.
         specversion:
           type: string
           description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -99,7 +99,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.5.0
+  version: 0.6.0-wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:
Uses a simple string for the "type" property in CloudEvent instead of an enum.



#### Which issue(s) this PR fixes:

Fixes #107 

