### PR TITLE
fix: add missing "subscriptionId" in "RoamingStatus"-data for CloudEvent

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -99,7 +99,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.5.0
+  version: 0.6.0-wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
@@ -893,6 +893,8 @@ components:
           $ref: "#/components/schemas/CountryCode"
         countryName:
           $ref: "#/components/schemas/CountryName"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
 
     RoamingChangeCountry:
       description: Event detail structure for org.camaraproject.device-status.v0.roaming-on event

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -99,7 +99,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.6.0-wip
+  version: 0.5.1-wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:
In the examples of callback CloudEvents for roaming-status, there is the subscriptionId given, but not in the corresponding component.
This will be fixed with this PR.

