### PR TITLE
fix: change description that subscriptionExpireTime is optional

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -81,7 +81,7 @@ info:
 
     Note: Additionally to these list, ``org.camaraproject.device-status.v0.subscription-ends`` notification `type` is sent when the subscription ends.
     This notification does not require dedicated subscription.
-    It is used when the subscription expire time (required by the requester) has been reached or if the API server has to stop sending notification prematurely.
+    It is used when the subscription expire time (optionally set by the requester) has been reached or if the API server has to stop sending notification prematurely.
 
     ### Notifications callback
 
@@ -99,7 +99,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.6.0-wip
+  version: 0.5.1-wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -99,7 +99,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.5.1-wip
+  version: 0.6.0-wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:
Correct the description for "subscription-ends" that this event will be send, when subscription expire time is optionally set by the requester.



#### Which issue(s) this PR fixes:


Fixes #116 