### PR TITLE
Updated in-line documentation for Roaming to clarify that country information can optionally be returned in the response.

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -16,7 +16,7 @@ info:
       - via direct request with the roaming situation in the response.
       - via a subscription  request - in this case the roaming situation is not in the response but event notification is sent back to the event subscriber when roaming situation has changed.
 
-    The verification of the roaming situation depends on the network's ability. Additionally to the roaming status, when the device is in roaming situation, visited country information is send back in the response.
+    The verification of the roaming situation depends on the network's ability. Additionally to the roaming status, when the device is in roaming situation, visited country information could be returned in the response.
 
     ## Connectivity Status
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Small update of in-line documentation for Roaming to clarify that country information can optionally be returned in the response. Previous documentation implied that country information was mandatory when roaming is true.

#### Which issue(s) this PR fixes:

Fixes #124 

#### Special notes for reviewers:

As discussed in DeviceStatus meeting on 13-03-24. It was agreed that country information is optional in cases of roaming=true.

#### Changelog input

```
 release-note
 Updated in-line documentation for Roaming to clarify that country information in response is optional.
```




