### PR TITLE
fix: change INVALID_INPUT for INVALID_ARGUMENT according to guidelines

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -361,24 +361,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SubscriptionInfo"
         "400":
-          description: Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorInfo"
-              examples:
-                Generic400:
-                  summary: Schema validation failed
-                  value:
-                    code: INVALID_INPUT
-                    status: 400
-                    message: "Schema validation failed at  ..."
-                subscriptionIdRequired:
-                  summary: eventSubscription id is required
-                  value:
-                    code: INVALID_INPUT
-                    status: 400
-                    message: "Expected property is missing: subscriptionId"
+          $ref: '#/components/responses/SubscriptionIdRequired'
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -415,24 +398,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SubscriptionAsync"
         "400":
-          description: Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorInfo"
-              examples:
-                Generic400:
-                  summary: Schema validation failed
-                  value:
-                    code: INVALID_INPUT
-                    status: 400
-                    message: "Schema validation failed at  ..."
-                subscriptionIdRequired:
-                  summary: eventSubscription id is required
-                  value:
-                    code: INVALID_INPUT
-                    status: 400
-                    message: "Expected property is missing: subscriptionId"
+          $ref: '#/components/responses/SubscriptionIdRequired'
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -997,6 +963,25 @@ components:
             status: 503
             code: "UNAVAILABLE"
             message: "Service unavailable"
+    SubscriptionIdRequired:
+      description: Problem with the client request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          examples:
+            Generic400:
+              summary: Schema validation failed
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: "Client specified an invalid argument, request body or query param"
+            subscriptionIdRequired:
+              summary: subscription id is required
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: "Expected property is missing: subscriptionId"
   examples:
     ROAMING_STATUS:
       value:

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -361,7 +361,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SubscriptionInfo"
         "400":
-          $ref: '#/components/responses/SubscriptionIdRequired'
+          $ref: "#/components/responses/Generic400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -398,7 +398,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SubscriptionAsync"
         "400":
-          $ref: '#/components/responses/SubscriptionIdRequired'
+          $ref: "#/components/responses/Generic400"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -963,25 +963,7 @@ components:
             status: 503
             code: "UNAVAILABLE"
             message: "Service unavailable"
-    SubscriptionIdRequired:
-      description: Problem with the client request
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          examples:
-            Generic400:
-              summary: Schema validation failed
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: "Client specified an invalid argument, request body or query param"
-            subscriptionIdRequired:
-              summary: subscription id is required
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: "Expected property is missing: subscriptionId"
+
   examples:
     ROAMING_STATUS:
       value:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug


#### What this PR does / why we need it:
Change old INVALID_INPUT 400 errors for INVALID_ARGUMENTS as stated in the commonalities guidelines
