### PR TITLE
Make '+' mandatory for phoneNumber

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -525,10 +525,10 @@ components:
       minProperties: 1
 
     PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, optionally prefixed with '+'.
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       type: string
-      pattern: '^\+?[0-9]{5,15}$'
-      example: "123456789"
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      example: "+123456789"
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
@@ -1043,7 +1043,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456789
+            phoneNumber: +123456789
           roaming: true
           countryCode: 208
           countryName: FR
@@ -1059,7 +1059,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456788
+            phoneNumber: +123456788
           subscriptionId: qs15-h556-rt89-1298
         time: 2023-01-18T13:18:23.682Z
 
@@ -1072,7 +1072,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456787
+            phoneNumber: +123456787
           subscriptionId: qs15-h556-rt89-1298
         time: 2023-01-19T13:18:23.682Z
 
@@ -1085,7 +1085,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456789
+            phoneNumber: +123456789
           countryCode: 214
           countryName: ["ES"]
           subscriptionId: qs15-h556-rt89-1298
@@ -1100,7 +1100,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456787
+            phoneNumber: +123456787
           subscriptionId: qs15-h556-rt89-1298
         time: 2023-01-19T13:18:23.682Z
 
@@ -1113,7 +1113,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456787
+            phoneNumber: +123456787
           subscriptionId: qs15-h556-rt89-1298
         time: 2023-01-19T13:18:23.682Z
 
@@ -1126,7 +1126,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456787
+            phoneNumber: +123456787
           subscriptionId: qs15-h556-rt89-1298
         time: 2023-01-19T13:18:23.682Z
 
@@ -1139,7 +1139,7 @@ components:
         datacontenttype: application/json
         data:
           device:
-            phoneNumber: 123456789
+            phoneNumber: +123456789
           terminationReason: SUBSCRIPTION_EXPIRED
           subscriptionId: qs15-h556-rt89-1298
         time: 2023-01-19T13:18:23.682Z


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

As required in Commonalities, this PR makes the '+' sign mandatory for the phoneNumber.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #136 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

``` Make '+' mandatory for phoneNumber + update documentation & examples accordingly.

#### Additional documentation 

This section can be blank.



```
docs

```
