### PR TITLE
Addition of "lastChecked" Field

### DIFF
--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -45,7 +45,7 @@ info:
       - `CONNECTED_DATA`, if device is connected to the network via data usage
       - `NOT_CONNECTED`, if device is not connected to the network
 
-    * **lastChecked** : Indicate when the information provided was last confirmed to be correct.
+    * **LastStatusTime** : This property specifies the time when the status was last checked. Its inclusion in the response indicates that the information may not be current, while its absence suggests that the status information is fresh.
     # API Functionality
 
     The API exposes following capabilities:
@@ -152,15 +152,15 @@ paths:
               examples:
                 Connected-With-SMS:
                   value:
-                    lastChecked: "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectivityStatus: CONNECTED_SMS
                 Connected-With-DATA:
                   value:
-                    lastChecked: "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectivityStatus: CONNECTED_DATA
                 Not-Connected:
                   value:
-                    lastChecked: "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectivityStatus: NOT_CONNECTED
         "400":
           $ref: "#/components/responses/Generic400"
@@ -205,19 +205,19 @@ paths:
               examples:
                 No-Country-Name:
                   value:
-                    lastChecked: "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 901
                     countryName: []
                 Single-Country-Code:
                   value:
-                    lastChecked: "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 262
                     countryName: ["DE"]
                 Multiple-Country-Codes:
                   value:
-                    lastChecked: "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 340
                     countryName: ["BL", "GF", "GP", "MF", "MQ"]
@@ -473,11 +473,10 @@ components:
     RoamingStatusResponse:
       type: object
       required:
-        - lastChecked
         - roaming
       properties:
-        lastChecked:
-          $ref: "#/components/schemas/LastChecked"
+        lastStatusTime:
+          $ref: "#/components/schemas/LastStatusTime"
         roaming:
           $ref: "#/components/schemas/ActiveRoaming"
         countryCode:
@@ -485,7 +484,7 @@ components:
         countryName:
           $ref: "#/components/schemas/CountryName"
 
-    LastChecked:
+    LastStatusTime:
       description: Last time that the associated device roaming status/connectivity was checked and, if necessary, updated
       type: string
       format: date-time
@@ -498,11 +497,10 @@ components:
     ConnectivityStatusResponse:
       type: object
       required:
-        - lastChecked
         - connectivityStatus
       properties:
-        lastChecked:
-          $ref: "#/components/schemas/LastChecked"
+        lastStatusTime:
+          $ref: "#/components/schemas/LastStatusTime"
         connectivityStatus:
           $ref: "#/components/schemas/ConnectivityStatus"
 

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -845,11 +845,11 @@ components:
       type: string
       format: date-time
       description: |
-        Timestamp of when the occurrence happened. 
-        If the time of the occurrence cannot be determined then this attribute MAY be set to some other time (such as the current time) by the CloudEvents producer, 
-        however all producers for the same source MUST be consistent in this respect. In other words, 
-        either they all use the actual time of the occurrence or they all use the same algorithm to determine the value used. 
-        It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. 
+        Timestamp of when the occurrence happened.
+        If the time of the occurrence cannot be determined then this attribute MAY be set to some other time (such as the current time) by the CloudEvents producer,
+        however all producers for the same source MUST be consistent in this respect. In other words,
+        either they all use the actual time of the occurrence or they all use the same algorithm to determine the value used.
+        It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
         Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
       example: "2018-04-05T17:31:00Z"
 

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -490,7 +490,7 @@ components:
       type: string
       format: date-time
       example: "2024-02-20T10:41:38.657Z"
-    
+ 
     ActiveRoaming:
       description: Roaming status. True, if it is roaming
       type: boolean

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -490,7 +490,7 @@ components:
       type: string
       format: date-time
       example: "2024-02-20T10:41:38.657Z"
-      
+    
     ActiveRoaming:
       description: Roaming status. True, if it is roaming
       type: boolean

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -46,7 +46,6 @@ info:
       - `NOT_CONNECTED`, if device is not connected to the network
 
     * **lastChecked** : Indicate when the information provided was last confirmed to be correct.
-    
     # API Functionality
 
     The API exposes following capabilities:

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -45,6 +45,8 @@ info:
       - `CONNECTED_DATA`, if device is connected to the network via data usage
       - `NOT_CONNECTED`, if device is not connected to the network
 
+    * **lastChecked** : Indicate when the information provided was last confirmed to be correct.
+    
     # API Functionality
 
     The API exposes following capabilities:
@@ -151,12 +153,15 @@ paths:
               examples:
                 Connected-With-SMS:
                   value:
+                    lastChecked: "2024-02-20T10:41:38.657Z"
                     connectivityStatus: CONNECTED_SMS
                 Connected-With-DATA:
                   value:
+                    lastChecked: "2024-02-20T10:41:38.657Z"
                     connectivityStatus: CONNECTED_DATA
                 Not-Connected:
                   value:
+                    lastChecked: "2024-02-20T10:41:38.657Z"
                     connectivityStatus: NOT_CONNECTED
         "400":
           $ref: "#/components/responses/Generic400"
@@ -201,16 +206,19 @@ paths:
               examples:
                 No-Country-Name:
                   value:
+                    lastChecked: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 901
                     countryName: []
                 Single-Country-Code:
                   value:
+                    lastChecked: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 262
                     countryName: ["DE"]
                 Multiple-Country-Codes:
                   value:
+                    lastChecked: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 340
                     countryName: ["BL", "GF", "GP", "MF", "MQ"]
@@ -466,8 +474,11 @@ components:
     RoamingStatusResponse:
       type: object
       required:
+        - lastChecked
         - roaming
       properties:
+        lastChecked:
+          $ref: "#/components/schemas/LastChecked"
         roaming:
           $ref: "#/components/schemas/ActiveRoaming"
         countryCode:
@@ -475,6 +486,12 @@ components:
         countryName:
           $ref: "#/components/schemas/CountryName"
 
+    LastChecked:
+      description: Last time that the associated device roaming status/connectivity was checked and, if necessary, updated
+      type: string
+      format: date-time
+      example: "2024-02-20T10:41:38.657Z"
+      
     ActiveRoaming:
       description: Roaming status. True, if it is roaming
       type: boolean
@@ -482,8 +499,11 @@ components:
     ConnectivityStatusResponse:
       type: object
       required:
+        - lastChecked
         - connectivityStatus
       properties:
+        lastChecked:
+          $ref: "#/components/schemas/LastChecked"
         connectivityStatus:
           $ref: "#/components/schemas/ConnectivityStatus"
 

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -490,7 +490,7 @@ components:
       type: string
       format: date-time
       example: "2024-02-20T10:41:38.657Z"
- 
+
     ActiveRoaming:
       description: Roaming status. True, if it is roaming
       type: boolean


### PR DESCRIPTION
What type of PR is this?
Add one of the following kinds:

correction

What this PR does / why we need it:
The CAMARA version of the current DeviceStatus API lacks a crucial "lastChecked" field, resulting in inconsistent behavior across vendors. This absence poses challenges for application developers in determining the freshness of roaming status/connectivity data.

Which issue(s) this PR fixes:
Fixes https://github.com/camaraproject/DeviceStatus/issues/110

