### PR TITLE
Prepare release r0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 ## Please note:
 - This release contains an alpha version of the API, it should be considered as a draft.
 - There are bug fixes to be expected and incompatible changes in upcoming versions.
-- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
 
 ## Device Status - v0.6.0-alpha.1
 - API definition **with inline documentation**: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,47 @@
 # Changelog DeviceStatus
 ## Table of Contents
+- [r0.6](#r06)
 - [v0.5.1](#v051)
 - [v0.5.0](#v050)
 - [v0.5.0-rc](#v050-rc)
 - [v0.4.1](#v041)
 - [v0.2.0](#v020)
+
+# r0.6  
+## Please note:
+- This is an alpha version, it should be considered as a draft.
+- There are bug fixes to be expected and incompatible changes in upcoming versions.
+- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+
+## Device Status - v0.6.0-alpha.1
+- API definition **with inline documentation**: 
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.6/code/API_definitions/device-status.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml)
+### Main Changes
+* Endpoints renamed 
+* New response parameter lastStatusTime
+
+### Added
+* Addition of "lastStatusTime" Field by @sachinvodafone in https://github.com/camaraproject/DeviceStatus/pull/146
+* include x-correlator by @fernandopradocabrillo in https://github.com/camaraproject/DeviceStatus/pull/112
+
+### Changed
+* Change endpoint names to comply with guideline by @gmuratk in https://github.com/camaraproject/DeviceStatus/pull/131
+* renaming "EventType"-components to be more clear & update component descriptions by @maxl2287 in https://github.com/camaraproject/DeviceStatus/pull/141
+* Make '+' mandatory for phoneNumber by @bigludo7 in https://github.com/camaraproject/DeviceStatus/pull/144
+
+### Fixed
+* NA
+
+### Removed
+* NA
+  
+## New Contributors
+* NA
+
+**Full Changelog**: https://github.com/camaraproject/DeviceStatus/compare/v0.5.0...r0.6
+
 
 # v0.5.1
 **This is a bugfix release for the third alpha version of the CAMARA DeviceStatus API**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,14 +43,14 @@
 
 
 # v0.5.1
-**This is a bugfix release for the third alpha version of the CAMARA DeviceStatus API**
+**This is a bugfix release for the third initial version of the CAMARA DeviceStatus API**
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.5.1/code/API_definitions/device-status.yaml)
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.5.1/code/API_definitions/device-status.yaml&nocors)
   - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.5.1/code/API_definitions/device-status.yaml)
 
 ## Please note:
-- This is an alpha version, it should be considered as a draft.
+- This is an initial version, it should be considered as a draft.
 - There are bug fixes to be expected and incompatible changes in upcoming versions.
 - The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
 
@@ -81,7 +81,7 @@
 
 
 # v0.5.0
-**This is the third alpha version of the CAMARA DeviceStatus API**
+**This is the third initial version of the CAMARA DeviceStatus API**
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.5.0/code/API_definitions/device-status.yaml)
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.5.0/code/API_definitions/device-status.yaml&nocors)
@@ -89,7 +89,7 @@
 
 ## Please note:
 - **This release contains significant changes compared to v0.4.1, and it is not backward compatible**
-- This is an alpha version, it should be considered as a draft.
+- This is an initial version, it should be considered as a draft.
 - There are bug fixes to be expected and incompatible changes in upcoming versions.
 - The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
 
@@ -127,7 +127,7 @@
 
 
 # v0.5.0-rc
-**This is the release candidate of v0.5.0 - containing the upcoming 3rd alpha version of the DeviceStatus API**
+**This is the release candidate of v0.5.0 - containing the upcoming 3rd initial version of the DeviceStatus API**
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.5.0-rc/code/API_definitions/device-status.yaml)
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.5.0-rc/code/API_definitions/device-status.yaml&nocors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 ## New Contributors
 * NA
 
-**Full Changelog**: https://github.com/camaraproject/DeviceStatus/compare/v0.5.0...r0.6
+**Full Changelog**: https://github.com/camaraproject/DeviceStatus/compare/v0.5.1...r0.6
 
 
 # v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 # r0.6  
 ## Please note:
-- This is an alpha version, it should be considered as a draft.
+- This release contains an alpha version of the API, it should be considered as a draft.
 - There are bug fixes to be expected and incompatible changes in upcoming versions.
 - The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Repository to describe, develop, document and test the DeviceStatus API family
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available public release**.
 
 <!-- following part left in for now but could be omitted going forward -->
-* The latest available and released version v0.6.0-alpha.1 of the API is available within the [release-0.6 branch](https://github.com/camaraproject/DeviceStatus/tree/release-0.6)
+* The latest available release version 0.6 (with API version 0.6.0-alpha.1) is available within the [release-0.6 branch](https://github.com/camaraproject/DeviceStatus/tree/release-0.6)
   - API definition with inline documentation:
     - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.6/code/API_definitions/device-status.yaml)
     - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml&nocors)

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Repository to describe, develop, document and test the DeviceStatus API family
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available public release**.
 
 <!-- following part left in for now but could be omitted going forward -->
-* The latest available release version 0.6 (with API version 0.6.0-alpha.1) is available within the [release-0.6 branch](https://github.com/camaraproject/DeviceStatus/tree/release-0.6)
+* The latest available release version 0.6 (with API version 0.6.0-alpha.1) is available [here](https://github.com/camaraproject/DeviceStatus/tree/r0.6)
   - API definition with inline documentation:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.6/code/API_definitions/device-status.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml) 
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/r0.6/code/API_definitions/device-status.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/r0.6/code/API_definitions/device-status.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/r0.6/code/API_definitions/device-status.yaml) 
 
 ## Contributing
 * Meetings

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Repository to describe, develop, document and test the DeviceStatus API family
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available public release**.
 
 <!-- following part left in for now but could be omitted going forward -->
-* The latest available and released version 0.5.1 of the API is available within the [release-0.5.1 branch](https://github.com/camaraproject/DeviceStatus/tree/release-0.5.1)
+* The latest available and released version v0.6.0-alpha.1 of the API is available within the [release-0.6 branch](https://github.com/camaraproject/DeviceStatus/tree/release-0.6)
   - API definition with inline documentation:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.5.1/code/API_definitions/device-status.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.5.1/code/API_definitions/device-status.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.5.1/code/API_definitions/device-status.yaml) 
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceStatus/blob/release-0.6/code/API_definitions/device-status.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceStatus/release-0.6/code/API_definitions/device-status.yaml) 
 
 ## Contributing
 * Meetings

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -101,7 +101,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.6.0-alpha.1
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/

--- a/code/API_definitions/device-status.yaml
+++ b/code/API_definitions/device-status.yaml
@@ -107,7 +107,7 @@ externalDocs:
   url: https://github.com/camaraproject/
 
 servers:
-  - url: "{apiRoot}/device-status/v0"
+  - url: "{apiRoot}/device-status/v0.6alpha1"
     variables:
       apiRoot:
         default: http://localhost:9091


### PR DESCRIPTION
#### What type of PR is this?

* subproject management


#### What this PR does / why we need it:

Prepare the release version 0.6 with the Device Status API version 0.6.0-alpha.1


#### Which issue(s) this PR fixes:


#### Special notes for reviewers:

Requesting for detailed review, since this is the first release following the new releasing guidelines.


#### Changelog input


#### Additional documentation 


