### PR TITLE
Switch device structure to optional

### DIFF
--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -245,8 +245,6 @@ components:
       properties:
         device:
           $ref: "#/components/schemas/Device"
-      required:
-        - device
 
     ErrorInfo:
       type: object

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -269,8 +269,6 @@ components:
       properties:
         device:
           $ref: "#/components/schemas/Device"
-      required:
-        - device
 
     ErrorInfo:
       type: object


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature


#### What this PR does / why we need it:

Shift device structure cardinality to optional has the device identifier could be obtained from the 3-legs process.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #173 

#### Special notes for reviewers:



#### Changelog input

```
 release-note
- Device structure is now optional has the device identifier could be obtained from the 3-legs process.

```

#### Additional documentation 

This section can be blank.



```
docs

```
