### PR TITLE
Make device attribute optional for subscription requests

### DIFF
--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -506,9 +506,7 @@ components:
       properties:
         device:
           $ref: "#/components/schemas/Device"
-      required:
-        - device
-
+  
     Subscription:
       description: Represents a event-type subscription.
       type: object

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -510,8 +510,6 @@ components:
       properties:
         device:
           $ref: "#/components/schemas/Device"
-      required:
-        - device
 
     Subscription:
       description: Represents a event-type subscription.


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:

The device attribute in the subscription request has been made optional.


#### Which issue(s) this PR fixes:

Fixes #189 

#### Special notes for reviewers:



#### Changelog input

```
Make device attribute optional for subscription requests

```

#### Additional documentation 

