### PR TITLE
Removing note that the API-scope is limited to 4G and 5G

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Repository to describe, develop, document and test the DeviceStatus API family
 * Service APIs for “Device Status” (see APIBacklog.md)  
 * It provides the customer with the ability to:  
   * check if a device is losing connection to the network or gets reachable again, and the roaming status.
-  * NOTE: The scope of this API family should be limited (at least at a first stage) to 4G and 5G.  
 * Describe, develop, document and test the APIs (with 1-2 Telcos)  
 * Started: July 2022 
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:
Removes the scope limit of DeivceStatus for 4G and 5G



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #163 

