### PR TITLE
device-roaming-status-subscriptions: add missing enums to TerminationReason

### DIFF
--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -907,13 +907,17 @@ components:
     TerminationReason:
       type: string
       description: |
-        NETWORK_TERMINATED - API server stopped sending notification
-        SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
-        SUBSCRIPTION_DELETED - Subscription was deleted by the requester
+        - NETWORK_TERMINATED - API server stopped sending notification
+        - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
+        - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
+        - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
+        - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester) expiration time has been reached
       enum:
         - NETWORK_TERMINATED
         - SUBSCRIPTION_EXPIRED
         - SUBSCRIPTION_DELETED
+        - MAX_EVENTS_REACHED
+        - ACCESS_TOKEN_EXPIRED
 
   responses:
     CreateSubscriptionBadRequest400:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Missing enums added to TerminationReason


#### Which issue(s) this PR fixes:

Fixes #203 

#### Special notes for reviewers:



#### Changelog input

```
Missing enums added to TerminationReason

```

#### Additional documentation 

