### PR TITLE
Clarification for initialEvent use in documentation

### DIFF
--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -44,6 +44,26 @@ info:
       - the Access Token `sinkCredential` (optionally set by the requester) expiration time has been reached
       - the API server has to stop sending notification prematurely
 
+    **Note on combined usage of ``initialEvent`` and ``subscriptionMaxEvents``**: 
+    
+    If an event is triggered following ``initialEvent`` set to true, 
+    this event will be counted towards ``subscriptionMaxEvents`` (if provided). 
+
+        
+    **Clarification on ``initialEvent`` & ``event-type`` behaviour:**
+
+    Following table illustrate behaviour regarding event triggering depending on **initial** reachability state of the device:
+
+    | subscrived event-type | device reachability status at subscription time | event send if ``initialEvent`` set to true |
+    | ----------------------| ------------- | --------------- |
+    | reachability-data  | OK for data usage |   Yes |
+    | reachability-data  | disconnected or only SMS | No |
+    | reachability-sms  | OK for data usage | No |
+    | reachability-sms  |  only SMS | Yes |
+    | reachability-sms  | disconnected | No |
+    | reachability-disconnected  | OK for Data or SMS usage | No |
+    | reachability-disconnected  | disconnected | Yes |
+
     ### Notifications callback
 
     This endpoint describes the event notification received on subscription listener side when the event occurred.

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -46,6 +46,44 @@ info:
       - the Access Token `sinkCredential` (optionally set by the requester) expiration time has been reached
       - the API server has to stop sending notification prematurely
 
+    **Note on combined usage of ``initialEvent`` and ``subscriptionMaxEvents``**: 
+    
+    If an event is triggered following ``initialEvent`` set to true, 
+    this event will be counted towards ``subscriptionMaxEvents`` (if provided). 
+
+    **Clarification on ``initialEvent`` & ``event-type`` behaviour:**
+
+    Following table illustrate behaviour regarding event triggering depending on **initial** roaming state of the device:
+
+    | subscrived event-type | device roaming status at subscription time | event send if ``initialEvent`` set to true |
+    | ----------------------| ------------- | --------------- |
+    | roaming-status  | Roaming On |   Yes |
+    | roaming-status  | Roaming Off | Yes |
+    | roaming-on  | Roaming On | Yes |
+    | roaming-on  | Roaming Off | No |
+    | roaming-off  | Roaming On | No |
+    | roaming-off  | Roaming Off | Yes |
+    | roaming-change-country  | Roaming Off | No(*) |
+    | roaming-change-country  | Roaming On | No(*) |
+
+    (*) Use of ``initialEvent`` has no impact on roaming-change-country event-type.
+
+    **Clarification on ``roaming-change-country`` event-type:**
+
+    ``roaming-change-country`` event is send only when the device stays in roaming situation and change country.
+    Suppose a device from Germany & all event types subscribed:
+
+    - Device moves from Germany to France:
+        - triggered: roaming-status & roaming-on
+        - not triggered: roaming-change-country & roaming-off
+    - Device moves from France to Belgium:
+        - triggered: roaming-change-country
+        - not triggered: roaming-status,  roaming-on & roaming-off
+    - Device moves from Belgium back to Germany
+        - triggered: roaming-status & roaming-off
+        - not triggered: roaming-on & roaming-change-country
+
+
     ### Notifications callback
 
     This endpoint describes the event notification received on subscription listener side when the event occurred.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation

#### What this PR does / why we need it:

Clarify behavior of subscription/event server regarding use of initialEvent
Clarify roaming country change behavior


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #222 

#### Special notes for reviewers:

Adding @gmuratk as reviewer.


#### Changelog input

```
 release-note
device-reachability-status-subscriptions:
- update yaml documentation part for initialEvent
device-roaming-status-subscriptions:
- update yaml documentation part for initialEvent
- update yaml documentation part for initialEvent roaming country change behavior

```

#### Additional documentation 

This section can be blank.



```
docs

```
