### PR TITLE
[connected-network-type-subscriptions] remove allOf in sinkCredential

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -364,9 +364,7 @@ components:
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
+          $ref: "#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.
@@ -423,6 +421,7 @@ components:
             Example: Consumer request area entered event. If consumer sets initialEvent to true and device is already in the geofence, an event is triggered
 
     SinkCredential:
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
       type: object
       properties:
         credentialType:


### PR DESCRIPTION
#### What type of PR is this?

* correction



#### What this PR does / why we need it:

Remove allOf from sinkCredential. allOf with description causes problems in some code-generator


#### Which issue(s) this PR fixes:

Fixes #243 

#### Special notes for reviewers:



#### Changelog input

```
remove allOf with description in sinkCredential

```

#### Additional documentation 

