### PR TITLE
Clarification for initialEvent for connected-network-type-subscriptions

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -44,6 +44,18 @@ info:
       - the Access Token `sinkCredential` (optionally set by the requester) expiration time has been reached
       - the API server has to stop sending notification prematurely
 
+    **Note on combined usage of ``initialEvent`` and ``subscriptionMaxEvents``**:
+
+    If an event is triggered following ``initialEvent`` set to true,
+    this event will be counted towards ``subscriptionMaxEvents`` (if provided).
+
+
+    **Clarification on ``initialEvent`` & ``event-type`` behaviour:**
+
+    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediatly to provide the connected network type of the device targeted.
+    If the device is not connected, `UNKNOWN` is sent as ``connectedNetworkType`` in this notification.
+
+    
     ### Notifications callback
 
     This endpoint describes the event notification received on subscription listener side when the event occurred.

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -52,7 +52,7 @@ info:
 
     **Clarification on ``initialEvent`` & ``event-type`` behaviour:**
 
-    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediatly to provide the connected network type of the device targeted.
+    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediately to provide the connected network type of the device targeted.
     If the device is not connected, `UNKNOWN` is sent as ``connectedNetworkType`` in this notification.
 
     ### Notifications callback

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -55,7 +55,6 @@ info:
     When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediatly to provide the connected network type of the device targeted.
     If the device is not connected, `UNKNOWN` is sent as ``connectedNetworkType`` in this notification.
 
-    
     ### Notifications callback
 
     This endpoint describes the event notification received on subscription listener side when the event occurred.

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -52,8 +52,8 @@ info:
 
     **Clarification on ``initialEvent`` & ``event-type`` behaviour:**
 
-    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediately to provide the connected network type of the device targeted (except if the device is not connected).
-    Note: If the status can not be determined we send an inital event with ``connectedNetworkType`` valued to`UNKNOWN`.
+    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediately to provide the connected network type of the device targeted.
+    Note: If the status can not be determined, or if the device is not connected, we send an inital event with ``connectedNetworkType`` valued to`UNKNOWN`.
 
     ### Notifications callback
 

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -52,8 +52,8 @@ info:
 
     **Clarification on ``initialEvent`` & ``event-type`` behaviour:**
 
-    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediately to provide the connected network type of the device targeted.
-    If the device is not connected, `UNKNOWN` is sent as ``connectedNetworkType`` in this notification.
+    When ``initialEvent`` is set to ``true`` in the subscription request, a notification has to be sent immediately to provide the connected network type of the device targeted (except if the device is not connected).
+    Note: If the status can not be determined we send an inital event with ``connectedNetworkType`` valued to`UNKNOWN`.
 
     ### Notifications callback
 


### PR DESCRIPTION



#### What type of PR is this?

Add one of the following kinds:

* documentation



#### What this PR does / why we need it:

Clarification for initialEvent for connected-network-type-subscriptionsns.yaml


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #222 

#### Special notes for reviewers:



#### Changelog input

```
 release-note
- documentation: Clarification for initialEvent for connected-network-type-subscriptions

```

#### Additional documentation 

This section can be blank.



```
docs

```
