### PR TITLE
Add extended test cases for device-roaming-status and device-reachability-status + refactor *.feature-files

### DIFF
--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -360,9 +360,9 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_creation_401.3_invalid_access_token
+  @connected_network_type_subscriptions_creation_401.3_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And use BaseURL
     And the request body is set to a valid request body
     When the request "createConnectedNetworkTypeSubscription" is sent
@@ -389,9 +389,9 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_retrieve_401.6_invalid_access_token
+  @connected_network_type_subscriptions_retrieve_401.6_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "retrieveConnectedNetworkTypeSubscription" is sent
     Then the response header "Content-Type" is "application/json"
@@ -417,9 +417,9 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_delete_401.9_invalid_access_token
+  @connected_network_type_subscriptions_delete_401.9_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "deleteConnectedNetworkTypeSubscription" is sent
     Then the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -435,8 +435,8 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
   @connected_network_type_subscriptions_create_403.1_permission_denied
   Scenario: subscription creation without having the required scope
     # To test this, a token does not have the required scope
-    Given header "Authorization" set to access token referring different scope
-    And use BaseUrL
+    Given header "Authorization" set to an access token not including scope "connected-network-type-subscriptions:org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed:create"
+    And use BaseURL
     When the request "createConnectedNetworkTypeSubscription" is sent
     Then the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -512,11 +512,11 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
-  Scenario: subscription creation with invalid access token for requested events subscription
+  Scenario: Subscription creation with invalid access token for requested events subscription
     # Note - currently "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed" is the only valid subscription type for this API
-    Given the header "Authorization" set to an access token not including scope "connected-network-type-subscriptions:org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed:create"
+    Given the header "Authorization" set to an access token that includes only a single subscription scope
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request body property "$.types" is equal to a valid type other than "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
+    And the request body property "$.types" is equal to a valid type other than the event corresponding to the access token scope
     When the request "createConnectedNetworkTypeSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -186,7 +186,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     Given a valid subscription for a device exists with "subscriptionId" equal to "id"
     And the subscription property "$.subscriptionMaxEvents" is set to 1
     And the subscription property "$.sink" is a valid callback URL
-    When a single notification with property "$.type" equal to "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed" has been sent to the callback URL
+    When a single notification corresponding to subscription property "$.type" has been sent to the callback URL
     Then a subscription termination event notification is sent to the callback URL
     And the notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
     And the notification property "$.type" is equal to "org.camaraproject.connected-network-type-subscriptions.v0.subscription-ends"
@@ -196,11 +196,11 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
   @connected_network_type_subscriptions_11_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ends event on deletion
     Given a valid subscription for a device exists with "subscriptionId" equal to "id"
-    And the subscription property "$.sink" is a valid callback URL    When the request "createConnectedNetworkTypeSubscription" is sent
+    And the subscription property "$.sink" is a valid callback URL
     When the request "deleteConnectedNetworkTypeSubscription" is sent
     And the path parameter "subscriptionId" is set to "id"
-    Then the response status code is 202 or 204
-    And a subscription termination event notification is sent to the callback URL
+    And the response status code is 202 or 204
+    Then a subscription termination event notification is sent to the callback URL
     And the notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
     And the notification property "$.type" is equal to "org.camaraproject.connected-network-type-subscriptions.v0.subscription-ends"
     And the notification property "$.data.subscriptionId" is equal to "id"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -343,7 +343,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
   @connected_network_type_subscriptions_creation_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the request header "Authorization" is removed
-    And use BaseUrL
+    And use BaseURL
     And the request body is set to a valid request body
     When the request "createConnectedNetworkTypeSubscription" is sent
     Then the response property "$.status" is 401

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -362,7 +362,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
 
   @connected_network_type_subscriptions_creation_401.3_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And use BaseURL
     And the request body is set to a valid request body
     When the request "createConnectedNetworkTypeSubscription" is sent

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -149,8 +149,8 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations to m
     And event notification "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed" is received on callback-url
     And event notification "org.camaraproject.connected-network-type-subscriptions.v0.subscription-ends" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
-    And type="org.camaraproject.connected-network-type-subscriptions.v0.subscription-ends"
-    And the response property "$.terminationReason" is "MAX_EVENTS_REACHED"
+    And the notification request property $.type="org.camaraproject.connected-network-type-subscriptions.v0.subscription-ends"
+    And the notification request property $.data.terminationReason is "MAX_EVENTS_REACHED"
 
   @connected_network_type_subscriptions_11_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ends event on deletion

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -353,7 +353,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
   @connected_network_type_subscriptions_creation_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to a previously valid but now expired access token
-    And use BaseUrL
+    And use BaseURL
     And the request body is set to a valid request body
     When the request "createConnectedNetworkTypeSubscription" is sent
     Then the response property "$.status" is 401

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -32,7 +32,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And request property "$.protocol" is equal to "HTTP"
     And a valid phone number identified by "$.config.subscriptionDetail.device.phoneNumber"
     And request property "$.sink" is set to a valid callbackUrl
-    Then the response code is 201
+    Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
@@ -55,7 +55,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And request property "$.protocol" is equal to "HTTP"
     And request property "$.sink" is set to a valid callbackUrl
     And request property "$.config.subscriptionDetail.device.phoneNumber" is not present
-    Then the response code is 201
+    Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
@@ -78,7 +78,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And request property "$.types" is one of the allowed values "<subscription-creation-types>"
     And request property "$.protocol" is equal to "HTTP"
     And request property "$.sink" is set to a valid callbackUrl
-    Then the response code is 202
+    Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync"
@@ -94,7 +94,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the header "Authorization" is set to a valid access token which does not identify any device 
     When the request "retrieveConnectedNetworkTypeSubscription" is sent
     And the path parameter "subscriptionId" is set to "id"
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
@@ -107,7 +107,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the header "Authorization" is set to a valid access token which identifies the device associated with the subscription
     When the request "retrieveConnectedNetworkTypeSubscription"
     And the path parameter "subscriptionId" is set to "id"
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
@@ -119,7 +119,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     Given at least one subscription is existing for the API consumer making this request
     And the header "Authorization" is set to a valid access token which does not identify any device 
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
@@ -130,7 +130,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     Given the API consumer has at least one active subscription for the device
     And the header "Authorization" is set to a valid access token which identifies a valid device associated with one or more subscriptions
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
@@ -142,7 +142,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     Given the API consumer has no active subscriptions for the device
     And the header "Authorization" is set to a valid access token which identifies a valid device
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body is an empty array
@@ -152,7 +152,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     Given the API consumer has an active subscription with "subscriptionId" equal to "id"
     When the request "deleteConnectedNetworkTypeSubscription" is sent
     And the path parameter "subscriptionId" is set to "id"
-    Then the response code is 202 or 204
+    Then the response status code is 202 or 204
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And if the response property "$.status" is 204 then response body is not present
     And if the response property "$.status" is 202 then response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync" and the response property "$.id" is equal to "id"
@@ -199,7 +199,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the subscription property "$.sink" is a valid callback URL    When the request "createConnectedNetworkTypeSubscription" is sent
     When the request "deleteConnectedNetworkTypeSubscription" is sent
     And the path parameter "subscriptionId" is set to "id"
-    Then the response code is 202 or 204
+    Then the response status code is 202 or 204
     And a subscription termination event notification is sent to the callback URL
     And the notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
     And the notification property "$.type" is equal to "org.camaraproject.connected-network-type-subscriptions.v0.subscription-ends"
@@ -241,7 +241,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
   @connected_network_type_subscriptions_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And the request body property "$.device" is compliant with the schema but does not identify a device for which connectivity is managed by the API provider
+    And the request body property "$.device" is compliant with the schema but does not identify a device whose connectivity is managed by the API provider
     When the request "createConnectedNetworkTypeSubscription" is sent
     Then the response status code is 404
     And the response property "$.status" is 404
@@ -309,71 +309,62 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
 
   @connected_network_type_subscriptions_400.1_create_subscription_with_invalid_parameter
   Scenario: Create subscription with invalid parameter
-    Given use BaseURL
-    When the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response code is 400
+    Given the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_400.2_create_subscription_with_invalid_subscription_expire_time
   Scenario: Expiry time in past
-    Given use BaseURL
-    When a valid subscription request body
-    And the request "createConnectedNetworkTypeSubscription" is sent
-    And "$.config.subscriptionExpireTime" is set in the past
-    Then the response code is 400
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.config.subscriptionExpireTime" is set to a time in the past
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_400.3_invalid_eventType
   Scenario: Subscription creation with invalid event type
-    Given use BaseURL
-    When a valid subscription request body
-    And the request "createConnectedNetworkTypeSubscription" is sent
-    And the request body property "$.types" is set to invalid value
-    Then the response code is 400
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is set to a value other than "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_400.4_invalid_protocol
   Scenario: subscription creation with invalid protocol
-    Given use BaseURL
-    When the request "createConnectedNetworkTypeSubscription" is sent
-    And a valid subscription request body
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     And the request property "$.protocol" is not equal to "HTTP"
-    Then the response property "$.status" is 400
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_PROTOCOL"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_400.5_create_subscription_with_invalid_credential_type
   Scenario: subscription creation with invalid credential type
-    Given use BaseURL
-    When the request "createConnectedNetworkTypeSubscription" is sent
-    And a valid subscription request body
-    And the request property "$.sink" is set to a valid callbackUrl
-    And the request property "$.sinkCredential.credentialType" is not equal to "ACCESSTOKEN"
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     And the request property "$.sinkCredential.accessTokenType" is equal to "bearer"
-    And the request property "$.sinkCredential.accessToken" is set to a valid value
-    And the request property "$.sinkCredential.accessTokenExpiresUtc" is set to a valid value
-    Then the response property "$.status" is 400
+    And the request property "$.sinkCredential.credentialType" is not equal to "ACCESSTOKEN"
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_CREDENTIAL"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_400.6_create_subscription_with_invalid_access_token_type
   Scenario: subscription creation with invalid token
-    Given use BaseURL
-    When the request "createConnectedNetworkTypeSubscription" is sent
-    And request body complies with schema '#/components/schema/SubscriptionRequest'
-    And the request property "$.sink" is set to a valid callbackUrl
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     And the request property "$.sinkCredential.credentialType" is equal to "ACCESSTOKEN"
     And the request property "$.sinkCredential.accessTokenType" is not equal to "bearer"
-    And the request property "$.sinkCredential.accessToken" is set to a valid value
-    And the request property "$.sinkCredential.accessTokenExpiresUtc" is set to a valid value
-    Then the response property "$.status" is 400
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_TOKEN"
     And the response property "$.message" contains a user friendly text
 
@@ -384,90 +375,125 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
   @connected_network_type_subscriptions_creation_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the request header "Authorization" is removed
-    And use BaseURL
-    And the request body is set to a valid request body
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 401
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_creation_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to a previously valid but now expired access token
-    And use BaseURL
-    And the request body is set to a valid request body
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 401
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_creation_401.3_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseURL
-    And the request body is set to a valid request body
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.4_no_authorization_header
   Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And use BaseUrL
+    Given the request header "Authorization" is removed
     When the request "retrieveConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 401
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.5_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
+    Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "retrieveConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 401
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.6_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
     When the request "retrieveConnectedNetworkTypeSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.7_no_authorization_header
   Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And use BaseUrL
+    Given the request header "Authorization" is removed
     When the request "deleteConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 401
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.8_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
+    Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "deleteConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 401
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.9_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
     When the request "deleteConnectedNetworkTypeSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
+  @connected_network_type_subscriptions_retrieve__list_401.10_no_authorization_header
+  Scenario: No Authorization header
+    Given the request header "Authorization" is removed
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
+
+  @connected_network_type_subscriptions_retrieve_list_401.11_expired_access_token
+  Scenario: Expired access token
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
+
+  @connected_network_type_subscriptions_retrieve_list_401.12_malformed_access_token
+  Scenario: Malformed access token
+    Given the header "Authorization" is set to a malformed token
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
 
 ##################
 # Error code 403
@@ -475,23 +501,25 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
 
   @connected_network_type_subscriptions_create_403.1_permission_denied
   Scenario: subscription creation without having the required scope
-    # To test this, a token does not have the required scope
-    Given header "Authorization" set to an access token not including scope "connected-network-type-subscriptions:org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed:create"
-    And use BaseURL
+    # To test this, a token must not have the required scope
+    Given the header "Authorization" set to an access token not including scope "connected-network-type-subscriptions:org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
     When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 403
+    Then the response status code is 403
+    And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
   Scenario: subscription creation with invalid access token for requested events subscription
-    # To test this, a token contains an unsupported event type for this API
-    Given a valid subscription request body
-    And use BaseUrL
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And the request body property "$.types" contains the supported event type in this API
+    # Note - currently "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed" is the only valid subscription type for this API
+    Given the header "Authorization" set to an access token not including scope "connected-network-type-subscriptions:org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to a valid type other than "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
     When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 403
+    Then the response status code is 403
+    And the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
     And the response property "$.message" contains a user friendly text
 
@@ -500,18 +528,20 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
 ##################
 
   @connected_network_type_subscriptions_404.1_retrieve_unknown_subscription_id
-  Scenario: Get subscription when subscription-id is unknown to the system
-    Given the path parameter property "$.subscriptionId" is unknown to the system
-    And use BaseURL
-    When the request "retrieveConnectedNetworkTypeSubscription" is sent with subscriptionId="id"
-    Then the response property "$.status" is 404
+  Scenario: Get subscription when subscriptionId is unknown to the system
+    Given that there is no valid subscription with "subscriptionId" equal to "id"
+    When the request "retrieveConnectedNetworkTypeSubscription" is sent
+    And the path parameter "subscriptionId" is equal to "id"
+    Then the response status code is 404
+    And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_404.2_delete_unknown_subscription_id
-  Scenario: Delete subscription with subscription-id unknown to the system
-    Given the path parameter "subscriptionId" is set to the value unknown to system
+  Scenario: Delete subscription with subscriptionId unknown to the system
+    Given that there is no valid subscription with "subscriptionId" equal to "id"
     When the request "deleteConnectedNetworkTypeSubscription" is sent
+    And the path parameter "subscriptionId" is equal to "id"
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -363,7 +363,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
   @connected_network_type_subscriptions_creation_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
-    And use BaseUrL
+    And use BaseURL
     And the request body is set to a valid request body
     When the request "createConnectedNetworkTypeSubscription" is sent
     Then the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -450,8 +450,8 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the request body property "$.device" is set to a valid testing device supported by the service
     And header "Authorization" set to access token referring different device
     When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 403
-    And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
+    Then the response property "$.status" is 422
+    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_create_403.3_subscription_mismatch_for_requested_events_subscription

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -442,19 +442,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_create_403.2_invalid_token_context
-  Scenario: subscription creation with invalid access token context for requested events subscription
-    # To test this, a token does not have the required device identifier
-    Given a valid subscription request body
-    And use BaseUrL
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And header "Authorization" set to access token referring different device
-    When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response property "$.status" is 422
-    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
-    And the response property "$.message" contains a user friendly text
-
-  @connected_network_type_subscriptions_create_403.3_subscription_mismatch_for_requested_events_subscription
+  @connected_network_type_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
   Scenario: subscription creation with invalid access token for requested events subscription
     # To test this, a token contains an unsupported event type for this API
     Given a valid subscription request body

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -352,7 +352,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
 
   @connected_network_type_subscriptions_creation_401.2_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
+    Given the header "Authorization" is set to a previously valid but now expired access token
     And use BaseUrL
     And the request body is set to a valid request body
     When the request "createConnectedNetworkTypeSubscription" is sent

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -461,7 +461,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
   @connected_network_type_subscriptions_404.1_retrieve_unknown_subscription_id
   Scenario: Get subscription when subscription-id is unknown to the system
     Given the path parameter property "$.subscriptionId" is unknown to the system
-    And use BaseUrL
+    And use BaseURL
     When the request "retrieveConnectedNetworkTypeSubscription" is sent with subscriptionId="id"
     Then the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -22,19 +22,39 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
 # Happy path scenarios
 ##########################
 
-  @connected_network_type_subscriptions_01_sync_creation
-  Scenario Outline: Create connected network type subscription synchronously
+  @connected_network_type_subscriptions_01.1_sync_creation_2legs
+  Scenario Outline: Check sync subscription creation with 2-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
     Given use BaseURL
     When the request "createConnectedNetworkTypeSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
-    And a valid phone number identified by the token or provided in the request body
+    And a valid phone number identified by "$.config.subscriptionDetail.device.phoneNumber"
     And "$.sink" is set to provided callbackUrl
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
-    And types, protocol, sink and config.subscriptionDetail.phoneNumber are present with provided value
+    And types, protocol, sink and config.subscriptionDetail.device.phoneNumber are present with provided value
+    And startsAt is valued with a datetime corresponding to the date time of the response
+
+    Examples:
+      | subscription-creation-types                                                             |
+      | org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed          |
+
+  @connected_network_type_subscriptions_01.2_sync_creation_3legs
+  Scenario Outline: Check sync subscription creation with 3-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
+    Given use BaseURL
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    And this device is identified by the token
+    And "$.types" is one of the allowed values "<subscription-creation-types>"
+    And "$.protocol"="HTTP"
+    And "$.sink" is set to provided callbackUrl
+    Then the response code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+    And types, protocol and sink are present with provided value
+    And config.subscriptionDetail.device is not existing in the response
     And startsAt is valued with a datetime corresponding to the date time of the response
 
     Examples:

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -361,7 +361,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_creation_401.3_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseURL
     And the request body is set to a valid request body
@@ -390,7 +390,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.6_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "retrieveConnectedNetworkTypeSubscription" is sent
@@ -418,7 +418,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0-rc.1 - Operatio
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.9_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "deleteConnectedNetworkTypeSubscription" is sent

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -182,9 +182,9 @@ Feature: CAMARA Connected Network Type API, v0.1.0-rc.1 - Operation getConnected
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_401.3_invalid_access_token
+  @connected_network_type_401.3_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And the request body is set to a valid request body
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 401

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -205,7 +205,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
     And the device is supported by the service, and may be connected or not connected to a mobile network
-    When the request "getRoamingStatus" is sent
+    When the request "getConnectedNetworkType" is sent
     And a network error prevents the connected network type from being retrieved
     Then the response status code is 503
     And the response property "$.status" is 503

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -1,5 +1,5 @@
 @Connected_Network_Type
-Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve network type
+Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetworkType
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -17,7 +17,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
-    And the request body is set by default to a request body compliant with the schema
+    And the request body is set by default to a request body compliant with the schema "#/components/schemas/ConnectedNetworkTypeRequest"
 
 ##########################
 # Happy path scenarios

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -184,7 +184,7 @@ Feature: CAMARA Connected Network Type API, v0.1.0-rc.1 - Operation getConnected
 
   @connected_network_type_401.3_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And the request body is set to a valid request body
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 401

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -183,7 +183,7 @@ Feature: CAMARA Connected Network Type API, v0.1.0-rc.1 - Operation getConnected
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_401.3_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And the request body is set to a valid request body
     When the request "getConnectedNetworkType" is sent

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -1,4 +1,4 @@
-@Connected_network_type
+@Connected_Network_Type
 Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve network type
   # Input to be provided by the implementation to the tester
   #
@@ -34,6 +34,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ConnectedNetworkTypeResponse"
     And the response property "$.connectedNetworkType" is "2G" or "3G" or "4G" or "5G"
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
   @connected_network_type_02_retrieval_undetermined_network
   Scenario: The connected network type of the user device can not be determined
@@ -46,6 +47,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ConnectedNetworkTypeResponse"
     And the response property "$.connectedNetworkType" is "UNKNOWN"
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
 #################
 # Error scenarios for management of input parameter device
@@ -82,7 +84,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
   @connected_network_type_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And the request body property "$.device" is compliant with the schema but does not identify a valid device
+    And the request body property "$.device" is compliant with the schema but does not identify a device whose connectivity is managed by the API provider
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 404
     And the response property "$.status" is 404
@@ -92,7 +94,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
   @connected_network_type_C01.04_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
-    And the request body property "$.device" is set to a valid device
+    And the request body property "$.device" is set to a valid device, which may or may not be the same device that is identified by the access token
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
@@ -145,20 +147,6 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     And the response property "$.message" contains a user friendly text
 
 #################
-# Error code 400
-#################
-
-  @connected_network_type_400.1_max_age_schema_compliant
-  Scenario: Input property values doe not comply with the schema
-    Given a valid testing device supported by the service, identified by the token or provided in the request body
-    And the "maxAge" is set to 6a0
-    When the request "getConnectedNetworkType" is sent
-    Then the response status code is 400
-    And the response property "$.status" is 400
-    And the response property "$.code" is "INVALID_ARGUMENT"
-    And the response property "$.message" contains a user friendly text
-
-#################
 # Error code 401
 #################
 
@@ -169,7 +157,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_401.2_no_authorization_header
@@ -179,7 +167,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_401.3_malformed_access_token
@@ -190,7 +178,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
 #################
@@ -199,7 +187,6 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
 
   @connected_network_type_403_permissions_denied
   Scenario: Client does not have sufficient permissions to perform this action
-    # To test this, a token has to be obtained for a different device
     Given header "Authorization" set to an access token not including scope "connected-network-type:read"
     And the request body is set to a valid request body
     When the request "getConnectedNetworkType" is sent
@@ -207,3 +194,20 @@ Feature: CAMARA Connected Network Type API, vwip - Operations for retrieve netwo
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
+
+#################
+# Error code 503
+#################
+
+  @connected_network_type_503_network_error
+   Scenario: Network error temporarily prevents the connected network type from being retrieved
+    # This test is for use by the API provider only
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
+    And the request body is set to a valid request body
+    And the device is supported by the service, and may be connected or not connected to a mobile network
+    When the request "getRoamingStatus" is sent
+    And a network error prevents the connected network type from being retrieved
+    Then the response status code is 503
+    And the response property "$.status" is 503
+    And the response property "$.code" is "UNAVAILABLE"
+    And the response property "$.message" contains a user friendly text indicating a temporary network error

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -200,7 +200,7 @@ Feature: CAMARA Connected Network Type API, v0.1.0-rc.1 - Operation getConnected
   @connected_network_type_403_permissions_denied
   Scenario: Client does not have sufficient permissions to perform this action
     # To test this, a token has to be obtained for a different device
-    Given the header "Authorization" is set to a valid access token, but without the required scope
+    Given header "Authorization" set to an access token not including scope "connected-network-type:read"
     And the request body is set to a valid request body
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 403

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -242,77 +242,165 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     And the notification property "$.data.subscriptionId" is equal to "id"
     And the notification request property "$.data.terminationReason" is equal to "SUBSCRIPTION_DELETED"
 
+################
+# Error scenarios for management of input parameter device
+##################
+
+  @reachability_status_subscriptions_C01.01_device_empty
+  Scenario: The device value is an empty object
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "$.device" is set to: {}
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @reachability_status_subscriptions_C01.02_device_identifiers_not_schema_compliant
+  Scenario Outline: Some device identifier value does not comply with the schema
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+    Examples:
+      | device_identifier          | oas_spec_schema                             |
+      | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
+      | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
+      | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
+      | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+
+  # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
+  @reachability_status_subscriptions_C01.03_device_not_found
+  Scenario: Some identifier cannot be matched to a device
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "$.device" is compliant with the schema but does not identify a device whose connectivity is managed by the API provider
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 404
+    And the response property "$.status" is 404
+    And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+  @reachability_status_subscriptions_C01.04_unnecessary_device
+  Scenario: Device not to be included when it can be deduced from the access token
+    Given the header "Authorization" is set to a valid access token identifying a device
+    And the request body property "$.device" is also set to a valid device, which may or may not be the same device
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text
+
+  @reachability_status_subscriptions_C01.05_missing_device
+  Scenario: Device not included and cannot be deduced from the access token
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "$.device" is not included
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "MISSING_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text
+
+  @reachability_status_subscriptions_C01.06_unsupported_device
+  Scenario: None of the provided device identifiers is supported by the implementation
+    Given that some types of device identifiers are not supported by the implementation
+    And the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "$.device" only includes device identifiers not supported by the implementation
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text
+
+  # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
+  @reachability_status_subscriptions_C01.07_device_not_supported
+  Scenario: Service not available for the device
+    Given that the service is not available for all devices commercialized by the operator
+    And a valid device, identified by the token or provided in the request body, for which the service is not applicable
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user-friendly text
+
+  # Several identifiers provided but they do not identify the same device
+  # This scenario may happen with 2-legged access tokens, which do not identify a device
+  @reachability_status_subscriptions_C01.08_device_identifiers_mismatch
+  Scenario: Device identifiers mismatch
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And at least 2 types of device identifiers are supported by the implementation
+    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "IDENTIFIER_MISMATCH"
+    And the response property "$.message" contains a user friendly text
+
 ##################
 # Error code 400
 ##################
 
   @reachability_status_subscriptions_400.1_create_subscription_with_invalid_parameter
   Scenario: Create subscription with invalid parameter
-    Given use BaseURL
-    When the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the HTTP "POST" request is sent
-    Then the response code is 400
+    Given the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_400.2_create_subscription_with_invalid_subscription_expire_time
   Scenario: Expiry time in past
-    Given use BaseURL
-    When a valid subscription request body
-    And the HTTP "POST" request is sent
-    And "$.config.subscriptionExpireTime" is set in the past
-    Then the response code is 400
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.config.subscriptionExpireTime" is set to a time in the past
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_400.3_invalid_eventType
   Scenario: Subscription creation with invalid event type
-    Given use BaseURL
-    When a valid subscription request body
-    And the HTTP "POST" request is sent
-    And the request body property "$.types" is set to invalid value
-    Then the response code is 400
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is set to an invalid value
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_400.4_invalid_protocol
   Scenario: subscription creation with invalid protocol
-    Given use BaseURL
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.protocol" is not equal to "HTTP"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    And a valid subscription request body
-    And "$.protocol" <> "HTTP"
-    Then the response property "$.status" is 400
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_PROTOCOL"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_400.5_create_subscription_with_invalid_credential_type
   Scenario: subscription creation with invalid credential type
-    Given use BaseURL
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.sinkCredential.accessTokenType" is equal to "bearer"
+    And the request property "$.sinkCredential.credentialType" is not equal to "ACCESSTOKEN"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    And a valid subscription request body
-    And "$.sink" is set to provided callbackUrl
-    And "$.sinkCredential.credentialType" <> "ACCESSTOKEN"
-    And "$.sinkCredential.accessTokenType" = "bearer"
-    And "$.sinkCredential.accessToken" is valued with a valid value
-    And "$.sinkCredential.accessTokenExpiresUtc" is valued with a valid value
-    Then the response property "$.status" is 400
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_CREDENTIAL"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_400.6_create_subscription_with_invalid_access_token_type
   Scenario: subscription creation with invalid token
-    Given use BaseURL
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.sinkCredential.credentialType" is equal to "ACCESSTOKEN"
+    And the request property "$.sinkCredential.accessTokenType" is not equal to "bearer"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    And a valid subscription request body
-    And "$.sink" is set to provided callbackUrl
-    And "$.sinkCredential.credentialType" = "ACCESSTOKEN"
-    And "$.sinkCredential.accessTokenType" <> "bearer"
-    And "$.sinkCredential.accessToken" is valued with a valid value
-    And "$.sinkCredential.accessTokenExpiresUtc" is valued with a valid value
-    Then the response property "$.status" is 400
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_TOKEN"
     And the response property "$.message" contains a user friendly text
 
@@ -323,90 +411,124 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
   @reachability_status_subscriptions_creation_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
-    And use BaseUrL
-    And the request body is set to a valid request body
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.2_expired_access_token
-  Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
-    And the request body is set to a valid request body
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.3_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
-    And the request body is set to a valid request body
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.4_no_authorization_header
   Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And use BaseUrL
+    Given the request header "Authorization" is removed
     When the request "retrieveDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.5_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
+    Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "retrieveDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.6_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
     When the request "retrieveDeviceReachabilityStatusSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.7_no_authorization_header
   Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And use BaseUrL
+    Given the request header "Authorization" is removed
     When the request "deleteDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.8_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
+    Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "deleteDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.9_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
     When the request "deleteDeviceReachabilityStatusSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
+  @reachability_status_subscriptions_retrieve__list_401.10_no_authorization_header
+  Scenario: No Authorization header
+    Given the request header "Authorization" is removed
+    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
+
+  @reachability_status_subscriptions_retrieve_list_401.11_expired_access_token
+  Scenario: Expired access token
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
+
+  @reachability_status_subscriptions_retrieve_list_401.12_malformed_access_token
+  Scenario: Malformed access token
+    Given the header "Authorization" is set to a malformed token
+    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
 
 ##################
 # Error code 403
@@ -414,23 +536,48 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
 
   @reachability_status_subscriptions_create_403.1_permission_denied
   Scenario: subscription creation without having the required scope
-    # To test this, a token does not have the required scope
-    Given header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data:create"
-    And use BaseUrL
+    # To test this, a token must not have the required scope
+    Given the header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 403
+    Then the response status code is 403
+    And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
-  Scenario: subscription creation with invalid access token for requested events subscription
-    # To test this, a token contains an unsupported event type for this API
-    Given a valid subscription request body
-    And use BaseUrL
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And the request body property "$.types" contains the supported event type in this API
+  @reachability_status_subscriptions_create_403.2_permission_denied
+  Scenario: subscription creation without having the required scope
+    # To test this, a token must not have the required scope
+    Given the header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-sms:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-sms"
     When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 403
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @reachability_status_subscriptions_create_403.3_permission_denied
+  Scenario: subscription creation without having the required scope
+    # To test this, a token must not have the required scope
+    Given the header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-disconnected:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-disconnected"
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @reachability_status_subscriptions_create_403.4_subscription_mismatch_for_requested_events_subscription
+  Scenario: subscription creation with invalid access token for requested events subscription
+    Given the header "Authorization" set to an access token that includes only a single subscription scope
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to a valid type other than the event corresponding to the access token scope
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
     And the response property "$.message" contains a user friendly text
 

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -293,7 +293,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.3_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     And the request body is set to a valid request body
@@ -322,7 +322,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.6_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "retrieveDeviceReachabilityStatusSubscription" is sent
@@ -350,7 +350,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.9_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "deleteDeviceReachabilityStatusSubscription" is sent

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -25,7 +25,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_01_sync_creation
   Scenario Outline: Check sync subscription creation - This scenario could be bypass if async creation is provided (following scenario)
     Given use BaseURL
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
     And a valid phone number identified by the token or provided in the request body
@@ -46,7 +46,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_02_async_creation
   Scenario Outline: Check async subscription creation - This scenario could be bypass if previous scenario is provided
     Given use BaseURL
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
     And a valid phone number identified by the token or provided in the request body
@@ -66,7 +66,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: Check existing subscription is retrieved by id
     Given a subscription is existing and identified by an "id"
     And use BaseURL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
+    When the request "retrieveDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -76,7 +76,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: Check existing subscription(s) is/are retrieved in list
     Given at least one subscription is existing for the API client making this request
     And use BaseURL
-    When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
+    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -88,7 +88,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     Given a subscription is existing for the device
     And this device is identified by the token
     And use BaseURL
-    When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
+    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -100,7 +100,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     Given no subscription is existing for the device
     And this device is identified by the token
     And use BaseURL
-    When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
+    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -109,7 +109,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_07_delete_subscription_based_on_an_existing_subscription-id
   Scenario: Delete a subscription based on existing subscription-id.
     Given the path parameter "subscriptionId" is set to the identifier of an existing subscription
-    When the request "deleteDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
+    When the request "deleteDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
     Then the response code is 202 or 204
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And if the response property $.status is 204 then response body is not available
@@ -118,7 +118,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_08_receive_notification_when_device_reachability_changed_to_data_usage
   Scenario: Receive notification for reachability-data event
     Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
     Then the response code is 201
@@ -131,7 +131,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_09_receive_notification_when_device_reachability_changed_to_sms_usage
   Scenario: Receive notification for reachability-sms event
     Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-sms"
     Then the response code is 201
@@ -144,7 +144,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_10_receive_notification_when_device_reachability_changed_to_disconnected
   Scenario: Receive notification for reachability-disconnected event
     Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-disconnected"
     Then the response code is 201
@@ -157,7 +157,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_11_subscription_expiry
   Scenario: Receive notification for subscription-ends event on expiry
     Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.subscriptionExpireTime" is set to a value in the near future
     Then the response code is 201
@@ -170,7 +170,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_12_subscription_end_when_max_events
   Scenario: Receive notification for subscription-ends event on max events reached
     Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
     And the request body property "$.subscriptionMaxEvents" is set to 1 
@@ -184,10 +184,10 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_13_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ends event on deletion
     Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     Then the response code is 201
-    When the request "deleteDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
+    When the request "deleteDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
     Then the response code is 202 or 204
     And event notification "org.camaraproject.device-reachability-status-subscriptions.v0.subscription-ends" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
@@ -233,7 +233,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_400.4_invalid_protocol
   Scenario: subscription creation with invalid protocol
     Given use BaseURL
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And "$.protocol" <> "HTTP"
     Then the response property "$.status" is 400
@@ -243,7 +243,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_400.5_create_subscription_with_invalid_credential_type
   Scenario: subscription creation with invalid credential type
     Given use BaseURL
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And "$.sink" is set to provided callbackUrl
     And "$.sinkCredential.credentialType" <> "ACCESSTOKEN"
@@ -257,7 +257,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_400.6_create_subscription_with_invalid_access_token_type
   Scenario: subscription creation with invalid token
     Given use BaseURL
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     And a valid subscription request body
     And "$.sink" is set to provided callbackUrl
     And "$.sinkCredential.credentialType" = "ACCESSTOKEN"
@@ -277,7 +277,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     Given the header "Authorization" is removed
     And use BaseUrL
     And the request body is set to a valid request body
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -287,17 +287,17 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     Given the header "Authorization" is set to an expired access token
     And use BaseUrL
     And the request body is set to a valid request body
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.3_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And use BaseUrL
     And the request body is set to a valid request body
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -307,7 +307,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And use BaseUrL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent
+    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -316,16 +316,16 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And use BaseUrL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent
+    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.6_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And use BaseUrL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent
+    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -335,7 +335,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And use BaseUrL
-    When the request "deleteDeviceRoamingStatusSubscription" is sent
+    When the request "deleteDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -344,7 +344,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And use BaseUrL
-    When the request "deleteDeviceRoamingStatusSubscription" is sent
+    When the request "deleteDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -353,7 +353,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     And use BaseUrL
-    When the request "deleteDeviceRoamingStatusSubscription" is sent
+    When the request "deleteDeviceReachabilityStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -367,33 +367,21 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_create_403.1_permission_denied
   Scenario: subscription creation without having the required scope
     # To test this, a token does not have the required scope
-    Given header "Authorization" set to access token referring different scope
+    Given header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data:create"
     And use BaseUrL
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscriptions_create_403.2_invalid_token_context
-  Scenario: subscription creation with invalid access token context for requested events subscription
-    # To test this, a token does not have the required device identifier
-    Given a valid subscription request body
-    And use BaseUrL
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And header "Authorization" set to access token referring different device
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 403
-    And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-    And the response property "$.message" contains a user friendly text
-
-  @reachability_status_subscriptions_create_403.3_subscription_mismatch_for_requested_events_subscription
+  @reachability_status_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
   Scenario: subscription creation with invalid access token for requested events subscription
     # To test this, a token contains an unsupported event type for this API
     Given a valid subscription request body
     And use BaseUrL
     And the request body property "$.device" is set to a valid testing device supported by the service
     And the request body property "$.types" contains the supported event type in this API
-    When the request "createDeviceRoamingStatusSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     Then the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
     And the response property "$.message" contains a user friendly text
@@ -406,7 +394,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   Scenario: Get subscription when subscription-id is unknown to the system
     Given the path parameter property "$.subscriptionId" is unknown to the system
     And use BaseUrL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
+    When the request "retrieveDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
     Then the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
@@ -414,7 +402,7 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
   @reachability_status_subscriptions_404.2_delete_unknown_subscription_id
   Scenario: Delete subscription with subscription-id unknown to the system
     Given the path parameter "subscriptionId" is set to the value unknown to system
-    When the request "deleteDeviceRoamingStatusSubscription" is sent
+    When the request "deleteDeviceReachabilityStatusSubscription" is sent
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -576,7 +576,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     Given the header "Authorization" set to an access token that includes only a single subscription scope
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     And the request body property "$.types" is equal to a valid type other than the event corresponding to the access token scope
-    When the request "createConnectedNetworkTypeSubscription" is sent
+    When the request "createDeviceReachabilityStatusSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -535,7 +535,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
 ##################
 
   @reachability_status_subscriptions_create_403.1_permission_denied
-  Scenario: subscription creation without having the required scope
+  Scenario: Subscription creation without having the required scope
     # To test this, a token must not have the required scope
     Given the header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
@@ -547,7 +547,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_create_403.2_permission_denied
-  Scenario: subscription creation without having the required scope
+  Scenario: Subscription creation without having the required scope
     # To test this, a token must not have the required scope
     Given the header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-sms:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
@@ -559,7 +559,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_create_403.3_permission_denied
-  Scenario: subscription creation without having the required scope
+  Scenario: Subscription creation without having the required scope
     # To test this, a token must not have the required scope
     Given the header "Authorization" set to an access token not including scope "device-reachability-status-subscriptions:org.camaraproject.device-reachability-status-subscriptions.v0.reachability-disconnected:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
@@ -571,7 +571,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_create_403.4_subscription_mismatch_for_requested_events_subscription
-  Scenario: subscription creation with invalid access token for requested events subscription
+  Scenario: Subscription creation with invalid access token for requested events subscription
     Given the header "Authorization" set to an access token that includes only a single subscription scope
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     And the request body property "$.types" is equal to a valid type other than the event corresponding to the access token scope
@@ -586,18 +586,20 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
 ##################
 
   @reachability_status_subscriptions_404.1_retrieve_unknown_subscription_id
-  Scenario: Get subscription when subscription-id is unknown to the system
-    Given the path parameter property "$.subscriptionId" is unknown to the system
-    And use BaseUrL
-    When the request "retrieveDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
-    Then the response property "$.status" is 404
+  Scenario: Get subscription when subscriptionId is unknown to the system
+    Given that there is no valid subscription with "subscriptionId" equal to "id"
+    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
+    And the path parameter "subscriptionId" is equal to "id"
+    Then the response status code is 404
+    And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_404.2_delete_unknown_subscription_id
-  Scenario: Delete subscription with subscription-id unknown to the system
-    Given the path parameter "subscriptionId" is set to the value unknown to system
+  Scenario: Delete subscription with subscriptionId unknown to the system
+    Given that there is no valid subscription with "subscriptionId" equal to "id"
     When the request "deleteDeviceReachabilityStatusSubscription" is sent
+    And the path parameter "subscriptionId" is equal to "id"
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -22,19 +22,41 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
 # Happy path scenarios
 ##########################
 
-  @reachability_status_subscriptions_01_sync_creation
-  Scenario Outline: Check sync subscription creation - This scenario could be bypass if async creation is provided (following scenario)
+  @reachability_status_subscriptions_01.1_sync_creation_2legs
+  Scenario Outline: Check sync subscription creation with 2-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
     Given use BaseURL
     When the request "createDeviceReachabilityStatusSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
-    And a valid phone number identified by the token or provided in the request body
+    And a valid phone number identified by "$.config.subscriptionDetail.device.phoneNumber"
     And "$.sink" is set to provided callbackUrl
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
-    And types, protocol, sink and config.subscriptionDetail.phoneNumber are present with provided value
+    And types, protocol, sink and config.subscriptionDetail.device.phoneNumber are present with provided value
+    And startsAt is valued with a datetime corresponding to the date time of the response
+
+    Examples:
+      | subscription-creation-types                                                             |
+      | org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data         |
+      | org.camaraproject.device-reachability-status-subscriptions.v0.reachability-sms          |
+      | org.camaraproject.device-reachability-status-subscriptions.v0.reachability-disconnected |
+
+  @reachability_status_subscriptions_01.2_sync_creation_3legs
+  Scenario Outline: Check sync subscription creation with 3-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
+    Given use BaseURL
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    And this device is identified by the token
+    And "$.types" is one of the allowed values "<subscription-creation-types>"
+    And "$.protocol"="HTTP"
+    And "$.sink" is set to provided callbackUrl
+    Then the response code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+    And types, protocol and sink are present with provided value
+    And config.subscriptionDetail.device is not existing in the response
     And startsAt is valued with a datetime corresponding to the date time of the response
 
     Examples:

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -292,9 +292,9 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscriptions_creation_401.3_invalid_access_token
+  @reachability_status_subscriptions_creation_401.3_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     And the request body is set to a valid request body
     When the request "createDeviceReachabilityStatusSubscription" is sent
@@ -321,9 +321,9 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscriptions_retrieve_401.6_invalid_access_token
+  @reachability_status_subscriptions_retrieve_401.6_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "retrieveDeviceReachabilityStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
@@ -349,9 +349,9 @@ Feature: CAMARA Device Reachability Status API, v0.7.0-rc.1 - Operation to manag
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscriptions_delete_401.9_invalid_access_token
+  @reachability_status_subscriptions_delete_401.9_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "deleteDeviceReachabilityStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -420,6 +420,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.2_expired_access_token
+  Scenario: Expired access token
     Given the header "Authorization" is set to a previously valid but now expired access token
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createDeviceReachabilityStatusSubscription" is sent
@@ -603,4 +604,19 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+##################
+# Error code 422
+##################
+
+  @reachability_status_subscriptions_422.1_multi_event_not_supported
+  Scenario: Multi-event subscriptions are not supported
+    Given a valid 2- or 3-legged access token
+    And a request body that is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"
+    And request property "$.types" includes more than one subscription-type
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -191,7 +191,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     When the request "getReachabilityStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @device_reachability_status_401.3_malformed_access_token

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -16,7 +16,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
-    And the request body is set by default to a request body compliant with the schema
+    And the request body is set by default to a request body compliant with the schema "#/components/schemas/RequestReachabilityStatus"
 
 ##########################
 # Happy path scenarios

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -39,7 +39,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
   Scenario: Check the reachability status if device is connected with DATA
     Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
-    And the device is connected with data and supported by the service
+    And the device has data connectivity and is supported by the service
     When the request "getReachabilityStatus" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -118,7 +118,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
   @device_reachability_status_C01.04_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
-    And the request body property "$.device" is set to a valid device
+    And the request body property "$.device" is set to a valid device, which may or may not be the same device that is identified by the access token
     When the request "getReachabilityStatus" is sent
     Then the response status code is 422
     And the response property "$.status" is 422

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -36,7 +36,6 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response property "$.connectivity" includes "SMS"
     And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
-
   @device_reachability_status_02_reachable_and_connected_data
   Scenario: Check the reachability status if device is connected with DATA
     Given a valid testing device supported by the service, identified by the token or provided in the request body
@@ -224,3 +223,20 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
+
+#################
+# Error code 503
+#################
+
+  @device_reachability_status_503_network_error
+   Scenario: Network error temporarily prevents the device reachability status from being retrieved
+    # This test is for use by the API provider only
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
+    And the request body is set to a valid request body
+    And the device is supported by the service, and may be reachable or not reachable
+    When the request "getReachabilityStatus" is sent
+    And a network error prevents the device reachability status from being retrieved
+    Then the response status code is 503
+    And the response property "$.status" is 503
+    And the response property "$.code" is "UNAVAILABLE"
+    And the response property "$.message" contains a user friendly text indicating a temporary network error

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -49,6 +49,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes "DATA"
+    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
 
   @device_reachability_status_03_reachable_and_connected_data_and_sms
   Scenario: Check the reachability status if device is connected with DATA and SMS

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -50,7 +50,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
 
   @device_reachability_status_03_reachable_and_connected_data_and_sms
   Scenario: Check the reachability status if device is connected with DATA and SMS
-    Given a valid device reachability status request body
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
     And the device is connected with data and sms and supported by the service
     When the request "getReachabilityStatus" is sent

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -11,7 +11,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
   #
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status.yaml
 
-  Background: Common Device reachability status setup
+  Background: Common getReachabilityStatus setup
     Given the resource "{api-root}/device-reachability-status/vwip/retrieve" set as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -75,6 +75,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is false
+    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
     And the response property "$.connectivity" is not present
 
 #################

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -63,9 +63,9 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
 
   @device_reachability_status_04_not_reachable
   Scenario: Check the reachability status for an unreachable device
-    Given a valid device reachability status request body
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
-    And the device is not connected and supported by the service
+    And the device is supported by the service, but is not connected to the API provider's network
     When the request "getReachabilityStatus" is sent
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -24,7 +24,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
 
   @device_reachability_status_01_reachable_and_connected_sms
   Scenario: Check the reachability status if device is connected with SMS
-    Given a valid device reachability status request body
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
     And the device is connected with sms and supported by the service
     When the request "getReachabilityStatus" is sent

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -108,7 +108,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
   @device_reachability_status_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And the request body property "$.device" is compliant with the schema but does not identify a valid device
+    And the request body property "$.device" is compliant with the schema, but does not identify a device whose connectivity is managed by the API provider
     When the request "getReachabilityStatus" is sent
     Then the response status code is 404
     And the response property "$.status" is 404

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -181,7 +181,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     When the request "getReachabilityStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @device_reachability_status_401.2_no_authorization_header

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -63,6 +63,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes both "DATA" and "SMS"
+    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
 
   @device_reachability_status_04_not_reachable
   Scenario: Check the reachability status for an unreachable device

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -202,7 +202,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
 #################

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -215,7 +215,6 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
 
   @device_reachability_status_403_permission_denied
   Scenario: OAuth2 token access does not have the required scope
-    # To test this, a token has to be obtained for a different device
     Given header "Authorization" set to an access token not including scope "device-reachability-status:read"
     And the request body is set to a valid request body
     When the request "getReachabilityStatus" is sent

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -52,7 +52,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
   Scenario: Check the reachability status if device is connected with DATA and SMS
     Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
-    And the device is connected with data and sms and supported by the service
+    And the device has both data and sms connectivity, and is supported by the service
     When the request "getReachabilityStatus" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -34,7 +34,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes "SMS"
-    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
 
   @device_reachability_status_02_reachable_and_connected_data

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -1,4 +1,4 @@
-@Device_reachability_status
+@Device_Reachability_Status
 Feature: CAMARA Device reachability status API, vwip - Operation getReachabilityStatus
   # Input to be provided by the implementation to the tester
   #

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -1,5 +1,5 @@
 @Device_reachability_status
-Feature: CAMARA Device reachability status API, vwip - Operations for reachability status
+Feature: CAMARA Device reachability status API, vwip - Operation getReachabilityStatus
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -194,7 +194,7 @@ Feature: CAMARA Device Reachability Status API, v1.0.0-rc.1 - Operation getReach
     And the response property "$.message" contains a user friendly text
 
   @device_reachability_status_401.3_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And the request body is set to a valid request body
     When the request "getReachabilityStatus" is sent

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -193,9 +193,9 @@ Feature: CAMARA Device Reachability Status API, v1.0.0-rc.1 - Operation getReach
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @device_reachability_status_401.3_invalid_access_token
+  @device_reachability_status_401.3_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And the request body is set to a valid request body
     When the request "getReachabilityStatus" is sent
     Then the response status code is 401

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -71,7 +71,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is false
-    And the response property "$.connectivity" is not returned
+    And the response property "$.connectivity" is not present
 
 #################
 # Error scenarios for management of input parameter device

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -195,7 +195,7 @@ Feature: CAMARA Device Reachability Status API, v1.0.0-rc.1 - Operation getReach
 
   @device_reachability_status_401.3_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And the request body is set to a valid request body
     When the request "getReachabilityStatus" is sent
     Then the response status code is 401
@@ -211,7 +211,7 @@ Feature: CAMARA Device Reachability Status API, v1.0.0-rc.1 - Operation getReach
   @device_reachability_status_403_permission_denied
   Scenario: OAuth2 token access does not have the required scope
     # To test this, a token has to be obtained for a different device
-    Given the header "Authorization" is set to a valid access token, but without the required scope
+    Given header "Authorization" set to an access token not including scope "device-reachability-status:read"
     And the request body is set to a valid request body
     When the request "getReachabilityStatus" is sent
     Then the response status code is 403

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -149,7 +149,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
   # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
   @device_reachability_status_C01.07_device_not_supported
   Scenario: Service not available for the device
-    Given that the service is not available for all devices commercialized by the operator
+    Given that the service is not available for all devices commercialized by the API provider
     And a valid device, identified by the token or provided in the request body, for which the service is not applicable
     When the request "getReachabilityStatus" is sent
     Then the response status code is 422

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -34,6 +34,8 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes "SMS"
+    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
+
 
   @device_reachability_status_02_reachable_and_connected_data
   Scenario: Check the reachability status if device is connected with DATA

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -37,7 +37,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
 
   @device_reachability_status_02_reachable_and_connected_data
   Scenario: Check the reachability status if device is connected with DATA
-    Given a valid device reachability status request body
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
     And the device is connected with data and supported by the service
     When the request "getReachabilityStatus" is sent

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -49,7 +49,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes "DATA"
-    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
   @device_reachability_status_03_reachable_and_connected_data_and_sms
   Scenario: Check the reachability status if device is connected with DATA and SMS
@@ -63,7 +63,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes both "DATA" and "SMS"
-    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
   @device_reachability_status_04_not_reachable
   Scenario: Check the reachability status for an unreachable device
@@ -75,7 +75,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is false
-    And if the response property "$.lastStatusTime" is present, then this property is in a valid date-time format
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
     And the response property "$.connectivity" is not present
 
 #################

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -21,19 +21,42 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
 # Happy path scenarios
 ##########################
 
-  @roaming_status_subscriptions_01_sync_creation
-  Scenario Outline: Check sync subscription creation - This scenario could be bypass if async creation is provided (following scenario)
+  @roaming_status_subscriptions_01.1_sync_creation_2legs
+  Scenario Outline: Check sync subscription creation with 2-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
     Given use BaseURL
     When the request "createDeviceRoamingStatusSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
-    And a valid phone number identified by the token or provided in the request body
+    And a valid phone number identified by "$.config.subscriptionDetail.device.phoneNumber"
     And "$.sink" is set to provided callbackUrl
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
-    And types, protocol, sink and config.subscriptionDetail.phoneNumber are present with provided value
+    And types, protocol, sink and config.subscriptionDetail.device.phoneNumber are present with provided value
+    And startsAt is valued with a datetime corresponding to the date time of the response
+
+    Examples:
+      | subscription-creation-types                                                             |
+      | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status                 |
+      | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on                     |
+      | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off                    |
+      | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country         |
+
+  @roaming_status_subscriptions_01.2_sync_creation_3legs
+  Scenario Outline: Check sync subscription creation with 3-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
+    Given use BaseURL
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    And this device is identified by the token
+    And "$.types" is one of the allowed values "<subscription-creation-types>"
+    And "$.protocol"="HTTP"
+    And "$.sink" is set to provided callbackUrl
+    Then the response code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+    And types, protocol and sink are present with provided value
+    And config.subscriptionDetail.device is not existing in the response
     And startsAt is valued with a datetime corresponding to the date time of the response
 
     Examples:

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -413,7 +413,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_creation_401.3_invalid_access_token
+  @roaming_status_subscriptions_creation_401.3_malformed_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     And use BaseUrL
@@ -442,9 +442,9 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_retrieve_401.6_invalid_access_token
+  @roaming_status_subscriptions_retrieve_401.6_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "retrieveDeviceRoamingStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
@@ -470,9 +470,9 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_delete_401.9_invalid_access_token
+  @roaming_status_subscriptions_delete_401.9_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "deleteDeviceRoamingStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -24,7 +24,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_01_sync_creation
   Scenario Outline: Check sync subscription creation - This scenario could be bypass if async creation is provided (following scenario)
     Given use BaseURL
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
     And a valid phone number identified by the token or provided in the request body
@@ -46,7 +46,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_02_async_creation
   Scenario Outline: Check async subscription creation - This scenario could be bypass if previous scenario is provided
     Given use BaseURL
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And "$.types" is one of the allowed values "<subscription-creation-types>"
     And "$.protocol"="HTTP"
     And a valid phone number identified by the token or provided in the request body
@@ -67,7 +67,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Check existing subscription is retrieved by id
     Given a subscription is existing and identified by an "id"
     And use BaseURL
-    When the request "retrieveDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -77,7 +77,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Check existing subscription(s) is/are retrieved in list
     Given at least one subscription is existing for the API client making this request
     And use BaseURL
-    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
+    When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -89,7 +89,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given a subscription is existing for the device
     And this device is identified by the token
     And use BaseURL
-    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
+    When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -101,7 +101,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given no subscription is existing for the device
     And this device is identified by the token
     And use BaseURL
-    When the request "retrieveDeviceReachabilityStatusSubscriptionList" is sent
+    When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -110,7 +110,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_07_delete_subscription_based_on_an_existing_subscription-id
   Scenario: Delete a subscription based on existing subscription-id.
     Given the path parameter "subscriptionId" is set to the identifier of an existing subscription
-    When the request "deleteDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
+    When the request "deleteDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
     Then the response code is 202 or 204
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And if the response property $.status is 204 then response body is not available
@@ -121,7 +121,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given that subscriptions are created synchronously
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response code is 201
     And if the device switch from roaming "OFF" to roaming "ON"
     And event notification "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on" is received on callback-url
@@ -134,7 +134,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given that subscriptions are created synchronously
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response code is 201
     And if the device switch from roaming "ON" to roaming "OFF"
     Then event notification "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off" is received on callback-url
@@ -147,7 +147,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given that subscriptions are created synchronously
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response code is 201
     And if the device roaming-status changes
     Then event notification "roaming-status" is received on callback-url
@@ -160,7 +160,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given that subscriptions are created synchronously
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response code is 201
     And if the device roaming country changes
     Then event notification "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country" is received on callback-url
@@ -171,7 +171,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_12_subscription_expiry
   Scenario: Receive notification for subscription-ends event on expiry
     Given that subscriptions are created synchronously
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.subscriptionExpireTime" is set to a value in the near future
     Then the response code is 201
@@ -184,7 +184,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_13_subscription_end_when_max_events
   Scenario: Receive notification for subscription-ends event on max events reached
     Given that subscriptions are created synchronously
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And a valid subscription request body
     And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
     And the request body property "$.subscriptionMaxEvents" is set to 1
@@ -198,10 +198,10 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_14_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ends event on deletion
     Given that subscriptions are created synchronously
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And a valid subscription request body
     Then the response code is 201
-    When the request "deleteDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
+    When the request "deleteDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
     Then the response code is 202 or 204
     And event notification "org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
@@ -216,7 +216,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: The device value is an empty object
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "$.device" is set to: {}
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
@@ -226,7 +226,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario Outline: Some device identifier value does not comply with the schema
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
@@ -244,7 +244,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "$.device" is compliant with the schema but does not identify a valid device
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
@@ -254,7 +254,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
     And the request body property "$.device" is set to a valid device
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
@@ -264,7 +264,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Device not included and cannot be deduced from the access token
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "$.device" is not included
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "MISSING_IDENTIFIER"
@@ -275,7 +275,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given that some types of device identifiers are not supported by the implementation
     And the header "Authorization" is set to a valid access token which does not identify a single device
     And the request body property "$.device" only includes device identifiers not supported by the implementation
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
@@ -286,7 +286,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Service not available for the device
     Given that the service is not available for all devices commercialized by the operator
     And a valid device, identified by the token or provided in the request body, for which the service is not applicable
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
@@ -299,7 +299,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And at least 2 types of device identifiers are supported by the implementation
     And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "IDENTIFIER_MISMATCH"
@@ -309,7 +309,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Device identifiers mismatch
     Given the header "Authorization" is set to a valid access token which does not identify a single device
     And "$.types" includes more than one subscription-type
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED"
@@ -354,7 +354,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_400.4_invalid_protocol
   Scenario: subscription creation with invalid protocol
     Given use BaseURL
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And a valid subscription request body
     And "$.protocol" <> "HTTP"
     Then the response property "$.status" is 400
@@ -364,7 +364,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_400.5_create_subscription_with_invalid_credential_type
   Scenario: subscription creation with invalid credential type
     Given use BaseURL
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And a valid subscription request body
     And "$.sink" is set to provided callbackUrl
     And "$.sinkCredential.credentialType" <> "ACCESSTOKEN"
@@ -378,7 +378,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_400.6_create_subscription_with_invalid_access_token_type
   Scenario: subscription creation with invalid token
     Given use BaseURL
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     And a valid subscription request body
     And "$.sink" is set to provided callbackUrl
     And "$.sinkCredential.credentialType" = "ACCESSTOKEN"
@@ -398,7 +398,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given the header "Authorization" is removed
     And use BaseUrL
     And the request body is set to a valid request body
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -408,7 +408,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given the header "Authorization" is set to an expired access token
     And use BaseUrL
     And the request body is set to a valid request body
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -418,7 +418,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     Given the header "Authorization" is set to an invalid access token
     And use BaseUrL
     And the request body is set to a valid request body
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -428,7 +428,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And use BaseUrL
-    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -437,16 +437,16 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And use BaseUrL
-    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.6_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And use BaseUrL
-    When the request "retrieveDeviceReachabilityStatusSubscription" is sent
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -456,7 +456,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     And use BaseUrL
-    When the request "deleteDeviceReachabilityStatusSubscription" is sent
+    When the request "deleteDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
@@ -465,16 +465,16 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     And use BaseUrL
-    When the request "deleteDeviceReachabilityStatusSubscription" is sent
+    When the request "deleteDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.9_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And use BaseUrL
-    When the request "deleteDeviceReachabilityStatusSubscription" is sent
+    When the request "deleteDeviceRoamingStatusSubscription" is sent
     Then the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -488,33 +488,21 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_create_403.1_permission_denied
   Scenario: subscription creation without having the required scope
     # To test this, a token does not have the required scope
-    Given header "Authorization" set to access token referring different scope
+    Given header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status:create"
     And use BaseUrL
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_create_403.2_invalid_token_context
-  Scenario: subscription creation with invalid access token context for requested events subscription
-    # To test this, a token does not have the required device identifier
-    Given a valid subscription request body
-    And use BaseUrL
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And header "Authorization" set to access token referring different device
-    When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 403
-    And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-    And the response property "$.message" contains a user friendly text
-
-  @roaming_status_subscriptions_create_403.3_subscription_mismatch_for_requested_events_subscription
+  @roaming_status_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
   Scenario: subscription creation with invalid access token for requested events subscription
     # To test this, a token contains an unsupported event type for this API
     Given a valid subscription request body
     And use BaseUrL
     And the request body property "$.device" is set to a valid testing device supported by the service
     And the request body property "$.types" contains the supported event type in this API
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
     And the response property "$.message" contains a user friendly text
@@ -527,7 +515,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   Scenario: Get subscription when subscription-id is unknown to the system
     Given the path parameter property "$.subscriptionId" is unknown to the system
     And use BaseUrL
-    When the request "retrieveDeviceReachabilityStatusSubscription" is sent with subscriptionId="id"
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
     Then the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
@@ -535,7 +523,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
   @roaming_status_subscriptions_404.2_delete_unknown_subscription_id
   Scenario: Delete subscription with subscription-id unknown to the system
     Given the path parameter "subscriptionId" is set to the value unknown to system
-    When the request "deleteDeviceReachabilityStatusSubscription" is sent
+    When the request "deleteDeviceRoamingStatusSubscription" is sent
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -414,7 +414,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_creation_401.3_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to an invalid access token
     And use BaseUrL
     And the request body is set to a valid request body
@@ -443,7 +443,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.6_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "retrieveDeviceRoamingStatusSubscription" is sent
@@ -471,7 +471,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0-rc.1 - - Operation to m
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.9_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And use BaseUrL
     When the request "deleteDeviceRoamingStatusSubscription" is sent

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -1,5 +1,5 @@
-@DeviceStatusRoamingSubscription
-Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatus
+@Device_Status_Roaming_Subscription
+Feature: Device Roaming Status Subscriptions API, vwip - Operations createDeviceRoamingStatusSubscription, retrieveDeviceRoamingStatusSubscriptionList, retrieveDeviceRoamingStatusSubscription and deleteDeviceRoamingStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -7,11 +7,11 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
   # * List of device identifier types which are not supported, among: phoneNumber, networkAccessIdentifier, ipv4Address, ipv6Address
   #
   # Testing assets:
-  # * A device object which roaming status is known by the network when connected.
+  # * A device object whose roaming status is known by the network when connected.
   # * The known roaming status of the testing device
   # * A sink-url identified as "callbackUrl", which receives notifications
   #
-  # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml, version vwip
+  # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
     Given the resource "{apiroot}/device-roaming-status-subscriptions/vwip" as base-url
@@ -23,19 +23,24 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
 ##########################
 
   @roaming_status_subscriptions_01.1_sync_creation_2legs
-  Scenario Outline: Check sync subscription creation with 2-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
-    Given use BaseURL
+  Scenario Outline: Synchronous subscription creation with 2-legged-access-token
+    # Some implementations may only support asynchronous subscription creation
+    Given the header "Authorization" is set to a valid access token which does not identify any device
+    And the request body is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    And "$.types" is one of the allowed values "<subscription-creation-types>"
-    And "$.protocol"="HTTP"
+    And request property "$.types" is one of the allowed values "<subscription-creation-types>"
+    And request property "$.protocol" is equal to "HTTP"
     And a valid phone number identified by "$.config.subscriptionDetail.device.phoneNumber"
-    And "$.sink" is set to provided callbackUrl
-    Then the response code is 201
+    And request property "$.sink" is set to a valid callbackUrl
+    Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
-    And types, protocol, sink and config.subscriptionDetail.device.phoneNumber are present with provided value
-    And startsAt is valued with a datetime corresponding to the date time of the response
+    And the response properties "$.types", "$.protocol", "$.sink" and "$.config.subscriptionDetail.device.phoneNumber" are present with the values provided in the request
+    And the response property "$.id" is present
+    And the response property "$.startsAt", if present, has a valid value with date-time format
+    And the response property "$.expiresAt", if present, has a valid value with date-time format
+    And the response property "$.status", if present, has the value "ACTIVATION_REQUESTED", "ACTIVE" or "INACTIVE"
 
     Examples:
       | subscription-creation-types                                                             |
@@ -45,20 +50,25 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
       | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country         |
 
   @roaming_status_subscriptions_01.2_sync_creation_3legs
-  Scenario Outline: Check sync subscription creation with 3-legged-access-token - This scenario could be bypass if async creation is provided (following scenario)
-    Given use BaseURL
+  Scenario Outline: Synchronous subscription creation with 3-legged-access-token
+    # Some implementations may only support asynchronous subscription creation
+    Given the header "Authorization" is set to a valid access token which identifies a valid device
+    And the request body is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    And this device is identified by the token
-    And "$.types" is one of the allowed values "<subscription-creation-types>"
-    And "$.protocol"="HTTP"
-    And "$.sink" is set to provided callbackUrl
-    Then the response code is 201
+    And request property "$.types" is one of the allowed values "<subscription-creation-types>"
+    And request property "$.protocol" is equal to "HTTP"
+    And request property "$.sink" is set to a valid callbackUrl
+    And request property "$.config.subscriptionDetail.device.phoneNumber" is not present
+    Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
-    And types, protocol and sink are present with provided value
-    And config.subscriptionDetail.device is not existing in the response
-    And startsAt is valued with a datetime corresponding to the date time of the response
+    And the response properties "$.types", "$.protocol" and "$.sink" are present with the values provided in the request
+    And the response property "$.id" is present
+    And the response property "$.startsAt", if present, has a valid value with date-time format
+    And the response property "$.expiresAt", if present, has a valid value with date-time format
+    And the response property "$.status", if present, has the value "ACTIVATION_REQUESTED", "ACTIVE" or "INACTIVE"
+    And the response property "$.config.subscriptionDetail.device" is not present
 
     Examples:
       | subscription-creation-types                                                             |
@@ -68,17 +78,19 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
       | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country         |
 
   @roaming_status_subscriptions_02_async_creation
-  Scenario Outline: Check async subscription creation - This scenario could be bypass if previous scenario is provided
-    Given use BaseURL
+  Scenario Outline: Asynchronous subscription creation with 2- or 3-legged access token
+    # Some implementations may only support synchronous subscription creation
+    Given a valid target device, identified by either the access token or in the request body
+    And the request body is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    And "$.types" is one of the allowed values "<subscription-creation-types>"
-    And "$.protocol"="HTTP"
-    And a valid phone number identified by the token or provided in the request body
-    And "$.sink" is set to provided callbackUrl
-    Then the response code is 202
+    And request property "$.types" is one of the allowed values "<subscription-creation-types>"
+    And request property "$.protocol" is equal to "HTTP"
+    And request property "$.sink" is set to a valid callbackUrl
+    Then the response status code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync"
+    And the response property "$.id" is present
 
     Examples:
       | subscription-creation-types                                                             |
@@ -87,150 +99,164 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
       | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off                    |
       | org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country         |
 
-  @roaming_status_subscriptions_03_retrieve_by_id
-  Scenario: Check existing subscription is retrieved by id
-    Given a subscription is existing and identified by an "id"
-    And use BaseURL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
-    Then the response code is 200
+  @roaming_status_subscriptions_03.1_retrieve_by_id_2legs
+  Scenario: Check existing subscription is retrieved by id with a 2-legged access token
+    Given a subscription exists and has a subscriptionId equal to "id"
+    And the header "Authorization" is set to a valid access token which does not identify any device 
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent
+    And the path parameter "subscriptionId" is set to "id"
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response property "$.id" is equal to "id"
+    And the response property "$.config.subscriptionDetail.device" is present
+
+  @roaming_status_subscriptions_03.2_retrieve_by_id_3legs
+  Scenario: Check existing subscription is retrieved by id with a 3-legged access token
+    Given a subscription exists and has a subscriptionId equal to "id"
+    And the header "Authorization" is set to a valid access token which identifies the device associated with the subscription
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent
+    And the path parameter "subscriptionId" is set to "id"
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response property "$.id" is equal to "id"
+    And the response property "$.config.subscriptionDetail.device" is not present
 
   @roaming_status_subscriptions_04_retrieve_list_2legs
   Scenario: Check existing subscription(s) is/are retrieved in list
-    Given at least one subscription is existing for the API client making this request
-    And use BaseURL
+    Given at least one subscription is existing for the API consumer making this request
+    And the header "Authorization" is set to a valid access token which does not identify any device 
     When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And subscription(s) is/are listed
+    And the response body lists all subscriptions belonging to the API consumer
 
   @roaming_status_subscriptions_05_retrieve_list_3legs
   Scenario: Check existing subscription(s) is/are retrieved in list
-    Given a subscription is existing for the device
-    And this device is identified by the token
-    And use BaseURL
+    Given the API consumer has at least one active subscription for the device
+    And the header "Authorization" is set to a valid access token which identifies a valid device associated with one or more subscriptions
     When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the subscriptions for this device are listed
+    And the response body lists all subscriptions belonging to the API consumer for the identified device
+    And the response property "$.config.subscriptionDetail.device" is not present in any of the subscription records
 
   @roaming_status_subscriptions_06_retrieve_empty_list_3legs
   Scenario: Check no existing subscription is retrieved in list
-    Given no subscription is existing for the device
-    And this device is identified by the token
-    And use BaseURL
+    Given the API consumer has no active subscriptions for the device
+    And the header "Authorization" is set to a valid access token which identifies a valid device
     When the request "retrieveDeviceRoamingStatusSubscriptionList" is sent
-    Then the response code is 200
+    Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body is an empty list
+    And the response body is an empty array
 
   @roaming_status_subscriptions_07_delete_subscription_based_on_an_existing_subscription-id
-  Scenario: Delete a subscription based on existing subscription-id.
-    Given the path parameter "subscriptionId" is set to the identifier of an existing subscription
-    When the request "deleteDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
-    Then the response code is 202 or 204
+   Scenario: Delete the subscription with subscriptionId equal to "id"
+    Given the API consumer has an active subscription with "subscriptionId" equal to "id"
+    When the request "deleteDeviceRoamingStatusSubscription" is sent
+    And the path parameter "subscriptionId" is set to "id"
+    Then the response status code is 202 or 204
     And the response header "x-correlator" has same value as the request header "x-correlator"
-    And if the response property $.status is 204 then response body is not available
-    And if the response property $.status is 202 then response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync"
+    And if the response property "$.status" is 204 then response body is not present
+    And if the response property "$.status" is 202 then response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync" and the response property "$.id" is equal to "id"
 
   @roaming_status_subscriptions_08_receive_notification_when_roaming_status_changed_to_on
   Scenario: Receive notification for roaming-on event
-    Given that subscriptions are created synchronously
-    And a valid subscription request body
-    And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response code is 201
-    And if the device switch from roaming "OFF" to roaming "ON"
-    And event notification "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on" is received on callback-url
-    And sink credentials are received as expected
+    Given a valid subscription for that device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
+    And the subscription property "$.sink" is a valid callback URL
+    And the device is not roaming
+    When the device changes network and is now roaming
+    Then event notification "roaming-on" is sent to the specified callback URL
+    And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventRoamingOn"
-    And type="org.camaraproject.roaming-status-subscriptions.v0.roaming-on"
+    And the notification property "$.type" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
+    And the notification property "$.data.subscriptionId" is equal to "id"
 
   @roaming_status_subscriptions_09_receive_notification_when_roaming_status_changed_to_off
   Scenario: Receive notification for roaming-off event
-    Given that subscriptions are created synchronously
-    And a valid subscription request body
-    And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response code is 201
-    And if the device switch from roaming "ON" to roaming "OFF"
-    Then event notification "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off" is received on callback-url
-    And sink credentials are received as expected
+    Given a valid subscription for that device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
+    And the subscription property "$.sink" is a valid callback URL
+    And the device is roaming
+    When the device changes network and is now not roaming
+    Then event notification "roaming-off" is sent to the specified callback URL
+    And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventRoamingOff"
-    And type="org.camaraproject.roaming-status-subscriptions.v0.roaming-off"
+    And the notification property "$.type" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
+    And the notification property "$.data.subscriptionId" is equal to "id"
 
   @roaming_status_subscriptions_10_receive_notification_when_roaming_status_changed
   Scenario: Receive notification for roaming-status changes
-    Given that subscriptions are created synchronously
-    And a valid subscription request body
-    And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response code is 201
-    And if the device roaming-status changes
-    Then event notification "roaming-status" is received on callback-url
-    And sink credentials are received as expected
+    Given a valid subscription for that device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
+    And the subscription property "$.sink" is a valid callback URL
+    When the device changes its roaming status
+    Then event notification "roaming-status" is sent to the specified callback URL
+    And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventRoamingStatus"
-    And type="org.camaraproject.roaming-status-subscriptions.v0.roaming-status"
+    And the notification property "$.type" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
+    And the notification property "$.data.subscriptionId" is equal to "id"
 
   @roaming_status_subscriptions_11_receive_notification_when_roaming_change_country
   Scenario: Receive notification for roaming-change-country
-    Given that subscriptions are created synchronously
-    And a valid subscription request body
-    And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response code is 201
-    And if the device roaming country changes
-    Then event notification "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country" is received on callback-url
-    And sink credentials are received as expected
-    And notification body complies with the OAS schema at "#/components/schemas/RoamingChangeCountry"
-    And type="org.camaraproject.roaming-status-subscriptions.v0.roaming-change-country"
+    Given a valid subscription for that device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
+    And the subscription property "$.sink" is a valid callback URL
+    And the device is roaming
+    When the device changes to a network in a different country and is still roaming
+    Then event notification "roaming-change-country" is sent to the specified callback URL
+    And the sink credentials specified when the subscription was created are included
+    And notification body complies with the OAS schema at "#/components/schemas/EventRoamingChangeCountry"
+    And the notification property "$.type" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
+    And the notification property "$.data.subscriptionId" is equal to "id"
+    And the notification property "$.data.countryCode" is present and equal to a valid country code
+    And the notification property "$.data.countryName" is present and includes a list of all countries corresponding to the country code
 
   @roaming_status_subscriptions_12_subscription_expiry
   Scenario: Receive notification for subscription-ends event on expiry
-    Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    And a valid subscription request body
-    And the request body property "$.subscriptionExpireTime" is set to a value in the near future
-    Then the response code is 201
-    And the subscription is expired
-    And event notification "subscription-ends" is received on callback-url
-    And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
-    And type="org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends"
-    And the response property "$.terminationReason" is "SUBSCRIPTION_EXPIRED"
+    Given a valid subscription for a device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.subscriptionExpireTime" is set to a value in the near future
+    And the subscription property "$.sink" is a valid callback URL
+    When the subscriptionExpireTime is reached
+    Then a subscription termination event notification is sent to the callback URL
+    And the notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
+    And the notification property "$.type" is "org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends"
+    And the notification property "$.data.subscriptionId" is equal to "id"
+    And the notification property "$.data.terminationReason" is equal to "SUBSCRIPTION_EXPIRED"
 
   @roaming_status_subscriptions_13_subscription_end_when_max_events
   Scenario: Receive notification for subscription-ends event on max events reached
-    Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    And a valid subscription request body
-    And the request body property "$.types" contains the element "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
-    And the request body property "$.subscriptionMaxEvents" is set to 1
-    Then the response code is 201
-    And event notification " org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status" is received on callback-url
-    And event notification "org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends" is received on callback-url
-    And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
-    And type="org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends"
-    And the response property "$.terminationReason" is "MAX_EVENTS_REACHED"
+    Given a valid subscription for a device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.subscriptionMaxEvents" is set to 1
+    And the subscription property "$.sink" is a valid callback URL
+    When a single notification corresponding to subscription property "$.type" has been sent to the callback URL
+    Then a subscription termination event notification is sent to the callback URL
+    And the notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
+    And the notification property "$.type" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends"
+    And the notification property "$.data.subscriptionId" is equal to "id"
+    And the notification request property "$.data.terminationReason" is equal to "MAX_EVENTS_REACHED"
 
   @roaming_status_subscriptions_14_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ends event on deletion
-    Given that subscriptions are created synchronously
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    And a valid subscription request body
-    Then the response code is 201
-    When the request "deleteDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
-    Then the response code is 202 or 204
-    And event notification "org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends" is received on callback-url
-    And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
-    And type="org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends"
-    And the response property "$.terminationReason" is "SUBSCRIPTION_DELETED"
+    Given a valid subscription for a device exists with "subscriptionId" equal to "id"
+    And the subscription property "$.sink" is a valid callback URL
+    When the request "deleteDeviceRoamingStatusSubscription" is sent
+    And the path parameter "subscriptionId" is set to "id"
+    And the response status code is 202 or 204
+    Then a subscription termination event notification is sent to the callback URL
+    And the notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnds"
+    And the notification property "$.type" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.subscription-ends"
+    And the notification property "$.data.subscriptionId" is equal to "id"
+    And the notification request property "$.data.terminationReason" is equal to "SUBSCRIPTION_DELETED"
 
 ################
 # Error scenarios for management of input parameter device
@@ -267,7 +293,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
   @roaming_status_subscriptions_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And the request body property "$.device" is compliant with the schema but does not identify a valid device
+    And the request body property "$.device" is compliant with the schema but does not identify a device whose connectivity is managed by the API provider
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 404
     And the response property "$.status" is 404
@@ -277,7 +303,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
   @roaming_status_subscriptions_C01.04_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
-    And the request body property "$.device" is set to a valid device
+    And the request body property "$.device" is also set to a valid device, which may or may not be the same device
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
@@ -329,87 +355,68 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
     And the response property "$.code" is "IDENTIFIER_MISMATCH"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_C01.08_multi_event_not_supported
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And "$.types" includes more than one subscription-type
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED"
-    And the response property "$.message" contains a user friendly text
-
 ##################
 # Error code 400
 ##################
 
   @roaming_status_subscriptions_400.1_create_subscription_with_invalid_parameter
   Scenario: Create subscription with invalid parameter
-    Given use BaseURL
-    When the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the HTTP "POST" request is sent
-    Then the response code is 400
+    Given the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_400.2_create_subscription_with_invalid_subscription_expire_time
   Scenario: Expiry time in past
-    Given use BaseURL
-    When a valid subscription request body
-    And the HTTP "POST" request is sent
-    And "$.config.subscriptionExpireTime" is set in the past
-    Then the response code is 400
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.config.subscriptionExpireTime" is set to a time in the past
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_400.3_invalid_eventType
   Scenario: Subscription creation with invalid event type
-    Given use BaseURL
-    When a valid subscription request body
-    And the HTTP "POST" request is sent
-    And the request body property "$.types" is set to invalid value
-    Then the response code is 400
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is set to an invalid value
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_400.4_invalid_protocol
   Scenario: subscription creation with invalid protocol
-    Given use BaseURL
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.protocol" is not equal to "HTTP"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    And a valid subscription request body
-    And "$.protocol" <> "HTTP"
-    Then the response property "$.status" is 400
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_PROTOCOL"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_400.5_create_subscription_with_invalid_credential_type
   Scenario: subscription creation with invalid credential type
-    Given use BaseURL
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.sinkCredential.accessTokenType" is equal to "bearer"
+    And the request property "$.sinkCredential.credentialType" is not equal to "ACCESSTOKEN"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    And a valid subscription request body
-    And "$.sink" is set to provided callbackUrl
-    And "$.sinkCredential.credentialType" <> "ACCESSTOKEN"
-    And "$.sinkCredential.accessTokenType" = "bearer"
-    And "$.sinkCredential.accessToken" is valued with a valid value
-    And "$.sinkCredential.accessTokenExpiresUtc" is valued with a valid value
-    Then the response property "$.status" is 400
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_CREDENTIAL"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_400.6_create_subscription_with_invalid_access_token_type
   Scenario: subscription creation with invalid token
-    Given use BaseURL
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.sinkCredential.credentialType" is equal to "ACCESSTOKEN"
+    And the request property "$.sinkCredential.accessTokenType" is not equal to "bearer"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    And a valid subscription request body
-    And "$.sink" is set to provided callbackUrl
-    And "$.sinkCredential.credentialType" = "ACCESSTOKEN"
-    And "$.sinkCredential.accessTokenType" <> "bearer"
-    And "$.sinkCredential.accessToken" is valued with a valid value
-    And "$.sinkCredential.accessTokenExpiresUtc" is valued with a valid value
-    Then the response property "$.status" is 400
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_TOKEN"
     And the response property "$.message" contains a user friendly text
 
@@ -420,21 +427,23 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
   @roaming_status_subscriptions_creation_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
-    And use BaseUrL
-    And the request body is set to a valid request body
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_creation_401.2_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
-    And the request body is set to a valid request body
-    When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    When the request "createDeviceReachabilityStatusSubscription" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_creation_401.3_malformed_access_token
@@ -551,4 +560,19 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations RoamingStatu
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
+
+##################
+# Error code 422
+##################
+
+  @roaming_status_subscriptions_C01.08_multi_event_not_supported
+  Scenario: Multi-event subscriptions are not supported
+    Given a valid 2- or 3-legged access token
+    And a request body that is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"
+    And request property "$.types" includes more than one subscription-type
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -439,7 +439,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
   Scenario: Expired access token
     Given the header "Authorization" is set to a previously valid but now expired access token
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    When the request "createDeviceReachabilityStatusSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -600,7 +600,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
     Given the header "Authorization" set to an access token that includes only a single subscription scope
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     And the request body property "$.types" is equal to a valid type other than the event corresponding to the access token scope
-    When the request "createConnectedNetworkTypeSubscription" is sent
+    When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -448,71 +448,104 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
 
   @roaming_status_subscriptions_creation_401.3_malformed_access_token
   Scenario: Malformed access token
-    Given the header "Authorization" is set to an invalid access token
-    And use BaseUrL
-    And the request body is set to a valid request body
+    Given the header "Authorization" is set to a malformed token
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.4_no_authorization_header
   Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And use BaseUrL
+    Given the request header "Authorization" is removed
     When the request "retrieveDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.5_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
+    Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "retrieveDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.6_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
     When the request "retrieveDeviceRoamingStatusSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.7_no_authorization_header
   Scenario: No Authorization header
-    Given the header "Authorization" is removed
-    And use BaseUrL
+    Given the request header "Authorization" is removed
     When the request "deleteDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.8_expired_access_token
   Scenario: Expired access token
-    Given the header "Authorization" is set to an expired access token
-    And use BaseUrL
+    Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "deleteDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.9_malformed_access_token
   Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
-    And use BaseUrL
     When the request "deleteDeviceRoamingStatusSubscription" is sent
-    Then the response header "Content-Type" is "application/json"
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
+  @roaming_status_subscriptions_retrieve__list_401.10_no_authorization_header
+  Scenario: No Authorization header
+    Given the request header "Authorization" is removed
+    When the request "deleteDeviceRoamingStatusSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
+
+  @roaming_status_subscriptions_retrieve_list_401.11_expired_access_token
+  Scenario: Expired access token
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    When the request "deleteDeviceRoamingStatusSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
+
+  @roaming_status_subscriptions_retrieve_list_401.12_malformed_access_token
+  Scenario: Malformed access token
+    Given the header "Authorization" is set to a malformed token
+    When the request "deleteDeviceRoamingStatusSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.message" contains a user friendly text
 
 ##################
 # Error code 403
@@ -520,23 +553,56 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
 
   @roaming_status_subscriptions_create_403.1_permission_denied
   Scenario: subscription creation without having the required scope
-    # To test this, a token does not have the required scope
-    Given header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status:create"
-    And use BaseUrL
+    Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 403
+    Then the response status code is 403
+    And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_create_403.2_subscription_mismatch_for_requested_events_subscription
-  Scenario: subscription creation with invalid access token for requested events subscription
-    # To test this, a token contains an unsupported event type for this API
-    Given a valid subscription request body
-    And use BaseUrL
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And the request body property "$.types" contains the supported event type in this API
+  @roaming_status_subscriptions_create_403.2_permission_denied
+  Scenario: subscription creation without having the required scope
+    Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
     When the request "createDeviceRoamingStatusSubscription" is sent
-    Then the response property "$.status" is 403
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @roaming_status_subscriptions_create_403.1_permission_denied
+  Scenario: subscription creation without having the required scope
+    Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @roaming_status_subscriptions_create_403.1_permission_denied
+  Scenario: subscription creation without having the required scope
+    Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country:create"
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
+    When the request "createDeviceRoamingStatusSubscription" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
+  @roaming_status_subscriptions_create_403.5_subscription_mismatch_for_requested_events_subscription
+  Scenario: Subscription creation with invalid access token for requested events subscription
+    Given the header "Authorization" set to an access token that includes only a single subscription scope
+    And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request body property "$.types" is equal to a valid type other than the event corresponding to the access token scope
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
     And the response property "$.message" contains a user friendly text
 
@@ -545,18 +611,20 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
 ##################
 
   @roaming_status_subscriptions_404.1_retrieve_unknown_subscription_id
-  Scenario: Get subscription when subscription-id is unknown to the system
-    Given the path parameter property "$.subscriptionId" is unknown to the system
-    And use BaseUrL
-    When the request "retrieveDeviceRoamingStatusSubscription" is sent with subscriptionId="id"
-    Then the response property "$.status" is 404
+  Scenario: Get subscription when subscriptionId is unknown to the system
+    Given that there is no valid subscription with "subscriptionId" equal to "id"
+    When the request "retrieveDeviceRoamingStatusSubscription" is sent
+    And the path parameter "subscriptionId" is equal to "id"
+    Then the response status code is 404
+    And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_404.2_delete_unknown_subscription_id
-  Scenario: Delete subscription with subscription-id unknown to the system
-    Given the path parameter "subscriptionId" is set to the value unknown to system
+  Scenario: Delete subscription with subscriptionId unknown to the system
+    Given that there is no valid subscription with "subscriptionId" equal to "id"
     When the request "deleteDeviceRoamingStatusSubscription" is sent
+    And the path parameter "subscriptionId" is equal to "id"
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -192,9 +192,9 @@ Feature: CAMARA Device Roaming Status API, v1.0.0-rc.1 - Operation getRoamingSta
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @device_roaming_status_401.3_invalid_access_token
+  @device_roaming_status_401.3_malformed_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to a malformed or expired token
+    Given the header "Authorization" is set to a malformed token
     And the request body is set to a valid request body
     When the request "getRoamingStatus" is sent
     Then the response status code is 401

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -12,7 +12,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
   # References to OAS spec schemas refer to schemas specifies in device-roaming-status.yaml
 
   Background: Common getRoamingStatus setup
-    Given the resource "/device-roaming-status/vwip/retrieve" set as base-url
+    Given the resource "{api-root}/device-roaming-status/vwip/retrieve" set as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -16,7 +16,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
-    And the request body is set by default to a request body compliant with the schema
+    And the request body is set by default to a request body compliant with the schema "#/components/schemas/RoamingStatusRequest"
 
 ##########################
 # Happy path scenarios

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -193,7 +193,7 @@ Feature: CAMARA Device Roaming Status API, v1.0.0-rc.1 - Operation getRoamingSta
     And the response property "$.message" contains a user friendly text
 
   @device_roaming_status_401.3_malformed_access_token
-  Scenario: Invalid access token
+  Scenario: Malformed access token
     Given the header "Authorization" is set to a malformed token
     And the request body is set to a valid request body
     When the request "getRoamingStatus" is sent

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -22,20 +22,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
 # Happy path scenarios
 ##########################
 
-  @device_roaming_status_01_roaming_status_true
-  Scenario: Check the roaming status when device is in the roaming mode
-    Given a valid testing device supported by the service, identified by the token or provided in the request body
-    And the request body is set to a valid request body
-    And the device which is in roaming and supported by the service
-    When the request "getRoamingStatus" is sent
-    Then the response code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with the OAS schema at "#/components/schemas/RoamingStatusResponse"
-    And the response property "$.roaming" is "true"
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
-
-  @device_roaming_status_01.1_roaming_status_true_with_country_code
+  @device_roaming_status_01_roaming_status_true_with_country_code
   Scenario: Check the roaming status when device is in the roaming mode
     Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
@@ -46,8 +33,8 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/RoamingStatusResponse"
     And the response property "$.roaming" is "true"
-    And if the response property "$.countryCode" is present, it has the value "262" as the Mobile Country Code (MCC) for Germany
-    And if the response property "$.countryName" is present, it is a non-empty array containing the ISO 3166 ALPHA-2 country-code ["DE"]
+    And the response property "$.countryCode" has the value "262" as the Mobile Country Code (MCC) for Germany
+    And the response property "$.countryName" is a non-empty array containing the ISO 3166 ALPHA-2 country-code ["DE"]
     And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
   @device_roaming_status_02_roaming_status_false
@@ -219,7 +206,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
 
   @device_roaming_status_503_network_error
    Scenario: Network error temporarily prevents the device roaming status from being retrieved
-    # This test is for testing by the API provider only
+    # This test is for use by the API provider only
     Given a valid testing device supported by the service, identified by the token or provided in the request body
     And the request body is set to a valid request body
     And the device is supported by the service, and may be roaming or not roaming

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -33,7 +33,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/RoamingStatusResponse"
     And the response property "$.roaming" is "true"
-    And if the response property "$.lastStatusTime" exists then the value has a valid date-time format
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
   @device_roaming_status_01.1_roaming_status_true_with_country_code
   Scenario: Check the roaming status when device is in the roaming mode
@@ -46,9 +46,9 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/RoamingStatusResponse"
     And the response property "$.roaming" is "true"
-    And if the response property "$.lastStatusTime" exists then this property is in a valid date-time format
-    And if the response property "$.countryCode" exists and has the value "262" as the Mobile Country Code (MCC) for Germany
-    And if the response property "$.countryName" exists and is a non-empty array containing the ISO 3166 ALPHA-2 country-code ["DE"]
+    And if the response property "$.countryCode" is present, it has the value "262" as the Mobile Country Code (MCC) for Germany
+    And if the response property "$.countryName" is present, it is a non-empty array containing the ISO 3166 ALPHA-2 country-code ["DE"]
+    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
 
   @device_roaming_status_02_roaming_status_false
   Scenario: Check the roaming state synchronously if the device is not in the roaming mode
@@ -61,9 +61,9 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/RoamingStatusResponse"
     And the response property "$.roaming" is "false"
-    And the response property "$.countryCode" does not exist
-    And the response property "$.countryName" does not exist
-    And if the response property "$.lastStatusTime" exists then this property is in a valid date-time format
+    And the response property "$.countryCode" is not present
+    And the response property "$.countryName" is not present
+    And if the response property "$.lastStatusTime" is present, then the value is a valid date-time format
 
 #################
 # Error scenarios for management of input parameter device
@@ -78,7 +78,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
-
 
   @device_roaming_status_C01.02_device_identifiers_not_schema_compliant
   Scenario Outline: Some device identifier value does not comply with the schema
@@ -102,24 +101,22 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
   @device_roaming_status_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
     Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And the request body property "$.device" is compliant with the schema but does not identify a valid device
+    And the request body property "$.device" is compliant with the schema, but does not identify a device whose connectivity is managed by the API provider
     When the request "getRoamingStatus" is sent
     Then the response status code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
-
   @device_roaming_status_C01.04_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
-    And the request body property "$.device" is set to a valid device
+    And the request body property "$.device" is set to a valid device, which may or may not be the same device that is identified by the access token
     When the request "getRoamingStatus" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user-friendly text
-
 
   @device_roaming_status_C01.05_missing_device
   Scenario: Device not included and cannot be deduced from the access token
@@ -130,7 +127,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.status" is 422
     And the response property "$.code" is "MISSING_IDENTIFIER"
     And the response property "$.message" contains a user-friendly text
-
 
   @device_roaming_status_C01.06_unsupported_device
   Scenario: None of the provided device identifiers is supported by the implementation
@@ -143,7 +139,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains a user-friendly text
 
-
   # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
   @device_roaming_status_C01.07_device_not_supported
   Scenario: Service not available for the device
@@ -154,7 +149,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.status" is 422
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
-
 
   # Several identifiers provided but they do not identify the same device
   # This scenario may happen with 2-legged access tokens, which do not identify a device
@@ -180,7 +174,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     When the request "getRoamingStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @device_roaming_status_401.2_no_authorization_header
@@ -190,7 +184,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     When the request "getRoamingStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
   @device_roaming_status_401.3_malformed_access_token
@@ -201,7 +195,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
 
 #################
@@ -218,3 +212,20 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.status" is 403
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
+
+#################
+# Error code 503
+#################
+
+  @device_roaming_status_503_network_error
+   Scenario: Network error temporarily prevents the device roaming status from being retrieved
+    # This test is for testing by the API provider only
+    Given a valid testing device supported by the service, identified by the token or provided in the request body
+    And the request body is set to a valid request body
+    And the device is supported by the service, and may be roaming or not roaming
+    When the request "getRoamingStatus" is sent
+    And a network error prevents the device roaming status from being retrieved
+    Then the response status code is 503
+    And the response property "$.status" is 503
+    And the response property "$.code" is "UNAVAILABLE"
+    And the response property "$.message" contains a user friendly text indicating a temporary network error

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -194,7 +194,7 @@ Feature: CAMARA Device Roaming Status API, v1.0.0-rc.1 - Operation getRoamingSta
 
   @device_roaming_status_401.3_invalid_access_token
   Scenario: Invalid access token
-    Given the header "Authorization" is set to an invalid access token
+    Given the header "Authorization" is set to a malformed or expired token
     And the request body is set to a valid request body
     When the request "getRoamingStatus" is sent
     Then the response status code is 401
@@ -210,7 +210,7 @@ Feature: CAMARA Device Roaming Status API, v1.0.0-rc.1 - Operation getRoamingSta
   @device_roaming_status_403_permission_denied
    Scenario: OAuth2 token access does not have the required scope
     # To test this, a token has to be obtained for a different device
-    Given the header "Authorization" is set to a valid access token, but without the required scope
+    Given header "Authorization" set to an access token not including scope "device-roaming-status:read"
     And the request body is set to a valid request body
     When the request "getRoamingStatus" is sent
     Then the response status code is 403

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -33,7 +33,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/RoamingStatusResponse"
     And the response property "$.roaming" is "true"
-    And if the response property "$.lastStatusTime" exists then this property is in a valid date-time format
+    And if the response property "$.lastStatusTime" exists then the value has a valid date-time format
 
   @device_roaming_status_01.1_roaming_status_true_with_country_code
   Scenario: Check the roaming status when device is in the roaming mode

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -83,7 +83,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
       | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
       | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
 
-
   # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
   @device_roaming_status_C01.03_device_not_found
   Scenario: Some identifier cannot be matched to a device
@@ -191,7 +190,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
 
   @device_roaming_status_403_permission_denied
    Scenario: OAuth2 token access does not have the required scope
-    # To test this, a token has to be obtained for a different device
     Given header "Authorization" set to an access token not including scope "device-roaming-status:read"
     And the request body is set to a valid request body
     When the request "getRoamingStatus" is sent


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* tests


#### What this PR does / why we need it:
This PR extends the testcases for:

* device-reachability-status
* device-roaming-status

#### Additionally this PR:

* aligns all *.feature - files on a common style.
* removes error-code `MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED` from `code/API_definitions/connected-network-type-subscriptions.yaml`


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #236 


#### Changelog input

```
 release-note
[device-reachability-status, device-roaming-status]: Add extended test cases for the planned stable apis
```

