### PR TITLE
Remove INVALID_TOKEN_CONTEXT error-code based on Commonalities 0.5.0-rc.1

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -1218,7 +1218,6 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - INVALID_TOKEN_CONTEXT
                       - SUBSCRIPTION_MISMATCH
           examples:
             GENERIC_403_PERMISSION_DENIED:
@@ -1227,12 +1226,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
             GENERIC_403_SUBSCRIPTION_MISMATCH:
               description: Inconsistent access token for requested subscription
               value:

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -1253,7 +1253,6 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - INVALID_TOKEN_CONTEXT
                       - SUBSCRIPTION_MISMATCH
           examples:
             GENERIC_403_PERMISSION_DENIED:
@@ -1262,12 +1261,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
             GENERIC_403_SUBSCRIPTION_MISMATCH:
               description: Inconsistent access token for requested subscription
               value:

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -1345,7 +1345,6 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - INVALID_TOKEN_CONTEXT
                       - SUBSCRIPTION_MISMATCH
           examples:
             GENERIC_403_PERMISSION_DENIED:
@@ -1354,12 +1353,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
             GENERIC_403_SUBSCRIPTION_MISMATCH:
               description: Inconsistent access token for requested subscription
               value:

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -215,18 +215,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations Reachab
     And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscription_20_invalid_token_context
-  Scenario: subscription creation with invalid access token context for requested events subscription
-    # To test this, a token does not have the required device identifier
-    Given a valid subscription request body
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And header "Authorization" set to access token referring different device
-    When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response property "$.status" is 403
-    And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-    And the response property "$.message" contains a user friendly text
-
-  @reachability_status_subscription_21_inconsistent_access_token_for_requested_events_subscription
+  @reachability_status_subscription_20_inconsistent_access_token_for_requested_events_subscription
   Scenario: subscription creation with invalid access token for requested events subscription
     # To test this, a token contains an unsupported event type for this API
     Given a valid subscription request body
@@ -237,7 +226,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations Reachab
     And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
     And the response property "$.message" contains a user friendly text
 
-  @reachability_status_subscription_22_unknown_subscription_id
+  @reachability_status_subscription_21_unknown_subscription_id
   Scenario: Get subscription when subscription-id is unknown to the system
     Given the path parameter property "$.subscriptionId" is unknown to the system
     When the request "retrieveDeviceReachabilityStatusSubscription" is sent

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -103,19 +103,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 	
-  @device_reachability_status_09_deviceStatus_inconsistent_access_token
-  Scenario: Inconsistent access token context for the device
-    # To test this, a token has to be obtained for a different device
-    Given a valid device reachability status request body
-    And the request body property "$.device" is set to a valid testing device supported by the service
-    And header "Authorization" set to access token referring different device
-    When the request "getReachabilityStatus" is sent
-    Then the response status code is 403
-    And the response property "$.status" is 403
-    And the response property "$.code" is "INVALID_TOKEN_CONTEXT"
-    And the response property "$.message" contains a user friendly text
-	
-  @device_reachability_status_10_deviceStatusWithIdentifiersMismatch
+  @device_reachability_status_09_deviceStatusWithIdentifiersMismatch
   Scenario: Device reachabilityidentifiers mismatch
     # To test this, at least 2 types of identifiers have to be provided, e.g. a phoneNumber and the IP address of a Device reachability associated to a different phoneNumber
     Given a valid device reachability status request body 
@@ -126,7 +114,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     And the response property "$.code" is "DEVICE_IDENTIFIERS_MISMATCH"
     And the response property "$.message" contains a user friendly text
 
-  @device_reachability_status_11_deviceStatus_NotApplicable
+  @device_reachability_status_10_deviceStatus_NotApplicable
   Scenario: Device reachability not applicable
     Given a valid device reachability status request body 
     And the request body property "$.device" refers to an unknown device
@@ -136,7 +124,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     And the response property "$.code" is "DEVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
-  @device_reachability_status_12_unable_to_provide_reachability_status
+  @device_reachability_status_11_unable_to_provide_reachability_status
   Scenario: Unable to provide reachability status for a device
     Given a valid device reachability status request body 
     And the request body property "$.device" refers to a device having network issue
@@ -146,7 +134,7 @@ Feature: CAMARA Device reachability status API, vwip - Operations for reachabili
     And the response property "$.code" is "UNABLE_TO_PROVIDE_REACHABILITY_STATUS"
     And the response property "$.message" contains a user friendly text
 
-  @device_reachability_status_13_unsupported_device_identifiers
+  @device_reachability_status_12_unsupported_device_identifiers
   Scenario: Unsupported device identifiers
     Given a valid device reachability status request body
     And the request body property "$.device" set to unsupported identifiers value for the service


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:
This PR removes the `INVALID_TOKEN_CONTEXT` error-code to allign on Commonalities v0.5.0-rc.1



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #256 


#### Changelog input

```
 release-note
* Remove INVALID_TOKEN_CONTEXT error-code based on Commonalities 0.5.0-rc.1
```
