### PR TITLE
Make lastStatusTime mandatory in 200 responses of the status APIs

### DIFF
--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -173,6 +173,7 @@ components:
     ConnectedNetworkTypeResponse:
       type: object
       required:
+        - lastStatusTime
         - connectedNetworkType
       properties:
         lastStatusTime:

--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -179,6 +179,7 @@ components:
     ReachabilityStatusResponse:
       type: object
       required:
+        - lastStatusTime
         - reachable
       properties:
         lastStatusTime:

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -182,6 +182,7 @@ components:
     RoamingStatusResponse:
       type: object
       required:
+        - lastStatusTime
         - roaming
       properties:
         lastStatusTime:


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
`lastStatusTime` is an optional parameter in the 200 responses of the status APIs. But there is no good reason not to include this parameter. Otherwise, there is the risk of ambiguity as to whether the returned status is still valid. It should be mandatory for any status that is not current, and the simplest way to enforce that is to make it mandatory for all responses.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #138 

#### Special notes for reviewers:
Could be part of Spring'25 meta-release if approved and merged today

#### Changelog input

```
 release-note
 - Make lastStatusTime mandatory in 200 responses of the status APIs
```

#### Additional documentation 
None