### PR TITLE
[subscriptions]: Set format `uri` instead of `url` for `sink`

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -103,14 +103,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.5
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/connected-network-type-subscriptions/v0.1"
+  - url: "{apiRoot}/connected-network-type-subscriptions/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -611,7 +611,7 @@ components:
           $ref: "#/components/schemas/Protocol"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -626,7 +626,7 @@ components:
           $ref: "#/components/schemas/Protocol"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -111,14 +111,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.7.0
+  version: wip
   x-camara-commonalities: 0.5
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/device-reachability-status-subscriptions/v0.7"
+  - url: "{apiRoot}/device-reachability-status-subscriptions/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -131,14 +131,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.7.0
+  version: wip
   x-camara-commonalities: 0.5
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/device-roaming-status-subscriptions/v0.7"
+  - url: "{apiRoot}/device-roaming-status-subscriptions/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -653,7 +653,7 @@ components:
           $ref: "#/components/schemas/Protocol"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -1,5 +1,5 @@
 @Connected_Network_Type_Subscription
-Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscriptionList, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
+Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscriptionList, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
   # References to OAS spec schemas refer to schemas specifies in connected-network-type-subscriptions.yaml
 
   Background: Connected Network Type Subscriptions setup
-    Given the resource "{apiroot}/connected-network-type-subscriptions/v0.1" as base-url
+    Given the resource "{apiroot}/connected-network-type-subscriptions/vwip" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
 

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -1,5 +1,5 @@
 @Device_Reachability_Status_Subscription
-Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations createDeviceReachabilityStatusSubscription, retrieveDeviceReachabilityStatusSubscriptionList, retrieveDeviceReachabilityStatusSubscription and deleteDeviceReachabilityStatusSubscription
+Feature: Device Reachability Status Subscriptions API, vwip - Operations createDeviceReachabilityStatusSubscription, retrieveDeviceReachabilityStatusSubscriptionList, retrieveDeviceReachabilityStatusSubscription and deleteDeviceReachabilityStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.7" as base-url
+    Given the resource "{apiroot}/device-reachability-status-subscriptions/vwip" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
 

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -1,5 +1,5 @@
 @Device_Status_Roaming_Subscription
-Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDeviceRoamingStatusSubscription, retrieveDeviceRoamingStatusSubscriptionList, retrieveDeviceRoamingStatusSubscription and deleteDeviceRoamingStatusSubscription
+Feature: Device Roaming Status Subscriptions API, vwip - Operations createDeviceRoamingStatusSubscription, retrieveDeviceRoamingStatusSubscriptionList, retrieveDeviceRoamingStatusSubscription and deleteDeviceRoamingStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -14,7 +14,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
   # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
-    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.7" as base-url
+    Given the resource "{apiroot}/device-roaming-status-subscriptions/vwip" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:
Sets the format for `sink` to `uri`.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #269 
